### PR TITLE
Fix/gloscope return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## 0.7.1
+
+### Changed
+
+-   Fixed typo in `GloScope` causing empty distance matrix
+
 ## 0.7.0
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true  # Allow installing packages from git repositorie
 
 [project]
 name = "patient_representation"
-version = "0.7.0"
+version = "0.7.1"
 description = "Representing patients or samples from single-cell data"
 readme = "README.md"
 requires-python = "~=3.10"

--- a/src/patient_representation/tl/basic.py
+++ b/src/patient_representation/tl/basic.py
@@ -1914,11 +1914,11 @@ class GloScope(SampleRepresentationMethod):
         )
 
         # Retrieve the distance matrix from R environment
-        dist_matrix = robjects.r("as.data.frame(dist_matrix)")
+        distances = robjects.r("as.data.frame(dist_matrix)")
 
-        self.sample_representation = dist_matrix
+        self.sample_representation = distances
         self.samples = list(self.sample_representation.index)
 
-        self.adata.uns[self.DISTANCES_UNS_KEY] = dist_matrix
+        self.adata.uns[self.DISTANCES_UNS_KEY] = distances
 
         return distances


### PR DESCRIPTION
Fixed typo in `GloScope` causing empty distance matrix