### PR TITLE
Fix/replicate robustness metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## 0.15.4
+
+### Fixed
+
+- `patpy.tl.evaluation.replicate_robustness` normalisation: the metric now reaches 0 in the worst case (replicate is the farthest neighbour for every sample).
+
+### Added
+
+- Tests for `replicate_robustness` covering best, worst, and intermediate configurations.
+- Expanded docstring for `replicate_robustness`.
+
 ## 0.15.3
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "patpy"
-version = "0.15.3"
+version = "0.15.4"
 description = "A toolbox for patient or sample representation from single-cell data"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/patpy/tl/evaluation.py
+++ b/src/patpy/tl/evaluation.py
@@ -739,7 +739,10 @@ def replicate_robustness(distances_df: pd.DataFrame, replicate_identity_function
         replicate_idx = np.where(replicate_identity_function(col, dists_to_others.index))[0].item()
         replicate_indexes[i] = replicate_idx
 
-    return 1 - np.mean(replicate_indexes)
+    # Max possible rank of a replicate is len(replicate_indexes) - 2: there are
+    # len(replicate_indexes) - 1 other samples after dropping self, indexed 0..n-2.
+    max_rank = len(replicate_indexes) - 2
+    return 1 - np.mean(replicate_indexes) / max_rank
 
 
 def associate_embedding_with_covariates(

--- a/src/patpy/tl/evaluation.py
+++ b/src/patpy/tl/evaluation.py
@@ -721,15 +721,57 @@ def knn_prediction_score(
 
 
 def replicate_robustness(distances_df: pd.DataFrame, replicate_identity_function=_identity_up_to_suffix) -> float:
-    """Compute the replicate robustness metric, which checks how close the repliicate samples are to each other
+    """Compute the replicate robustness metric, which checks how close the replicate samples are to each other.
+
+    For every sample, the rank of its replicate is found in the list of distances to
+    all other samples (sorted ascending, self excluded). Ranks are then averaged and
+    normalised so the score lies in ``[0, 1]``:
+
+    - ``1.0`` — every sample's replicate is its nearest neighbour (perfect robustness).
+    - ``0.0`` — every sample's replicate is its farthest neighbour (worst case).
+    - values in between mix the two regimes.
 
     Parameters
     ----------
-    distances_df: pd.DataFrame
-        The distances between samples. Must be a data frame with samples names in index and columns.
-    replicate_identity_function: Callable
-        A function that takes names of two samples and returns True if they are replicates
+    distances_df : pd.DataFrame
+        Square distance matrix with sample names on both index and columns. Each
+        sample is expected to have exactly one replicate present in the matrix
+        (besides itself).
+    replicate_identity_function : Callable, optional
+        Function ``(name, names) -> list[bool]`` that returns, for a single
+        sample ``name`` and an iterable of candidate ``names``, a boolean mask
+        flagging which candidates are replicates of ``name``. Exactly one
+        ``True`` is expected per call.
 
+        The default, :func:`_identity_up_to_suffix`, treats two samples as
+        replicates when their names match up to the part before the last
+        underscore. For instance ``"donor1_a"`` and ``"donor1_b"`` are
+        replicates (both strip to ``"donor1"``), while ``"donor1_a"`` and
+        ``"donor2_a"`` are not. Pass a custom function if your naming scheme
+        differs (e.g. replicates encoded in a separate metadata column).
+
+    Returns
+    -------
+    float
+        The replicate robustness score in ``[0, 1]``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> from patpy.tl.evaluation import replicate_robustness
+    >>> names = ["donor1_a", "donor1_b", "donor2_a", "donor2_b"]
+    >>> dist = np.array(
+    ...     [
+    ...         [0.0, 0.1, 1.0, 1.0],
+    ...         [0.1, 0.0, 1.0, 1.0],
+    ...         [1.0, 1.0, 0.0, 0.1],
+    ...         [1.0, 1.0, 0.1, 0.0],
+    ...     ]
+    ... )
+    >>> distances_df = pd.DataFrame(dist, index=names, columns=names)
+    >>> replicate_robustness(distances_df)
+    1.0
     """
     replicate_indexes = np.zeros(distances_df.shape[0])
 

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -12,6 +12,7 @@ from patpy.tl.evaluation import (
     evaluate_representation,
     knn_prediction_score,
     predict_knn,
+    replicate_robustness,
 )
 
 
@@ -161,3 +162,77 @@ def test_knn_prediction_score_reverse_technical_score():
 
     assert technical_reversed == pytest.approx(1 - technical_raw)
     assert relevant_reversed == pytest.approx(relevant_raw)
+
+
+def _make_replicate_distance_matrix(donor_donor: np.ndarray, replicate_distance: float) -> pd.DataFrame:
+    """Build an 8x8 distance DataFrame for 4 donors x 2 replicates.
+
+    ``donor_donor`` is a 4x4 symmetric matrix of inter-donor distances; each donor's
+    two replicates inherit those inter-donor distances and are placed
+    ``replicate_distance`` apart from each other.
+    """
+    n_donors = donor_donor.shape[0]
+    names = [f"donor{d}_{r}" for d in range(n_donors) for r in ("a", "b")]
+    n = len(names)
+    dist = np.zeros((n, n))
+    for i in range(n):
+        for j in range(n):
+            if i == j:
+                continue
+            di = i // 2
+            dj = j // 2
+            if di == dj:
+                dist[i, j] = replicate_distance
+            else:
+                dist[i, j] = donor_donor[di, dj]
+    return pd.DataFrame(dist, index=names, columns=names)
+
+
+# Replicate robustness should be 1 when each sample's replicate is its nearest neighbour.
+def test_replicate_robustness_perfect():
+    donor_donor = np.full((4, 4), 1.0)
+    np.fill_diagonal(donor_donor, 0.0)
+    distances_df = _make_replicate_distance_matrix(donor_donor, replicate_distance=0.1)
+
+    score = replicate_robustness(distances_df)
+
+    assert score == pytest.approx(1.0)
+
+
+# Replicate robustness should be 0 when each sample's replicate is its farthest neighbour.
+def test_replicate_robustness_worst():
+    donor_donor = np.full((4, 4), 0.1)
+    np.fill_diagonal(donor_donor, 0.0)
+    distances_df = _make_replicate_distance_matrix(donor_donor, replicate_distance=1.0)
+
+    score = replicate_robustness(distances_df)
+
+    assert score == pytest.approx(0.0)
+
+
+# Replicate robustness should fall strictly between 0 and 1 for a mixed configuration.
+def test_replicate_robustness_intermediate():
+    # 4 donors, 2 replicates each. donors 0 and 1 have replicates as nearest neighbours;
+    # donors 2 and 3 have their replicates pushed to the far end of the ranking.
+    names = [f"donor{d}_{r}" for d in range(4) for r in ("a", "b")]
+    n = len(names)
+    dist = np.full((n, n), 1.0)
+    np.fill_diagonal(dist, 0.0)
+
+    # Tight replicate pairs for donors 0, 1.
+    for d in (0, 1):
+        i, j = 2 * d, 2 * d + 1
+        dist[i, j] = dist[j, i] = 0.05
+
+    # Loose replicate pairs (max distance) for donors 2, 3.
+    for d in (2, 3):
+        i, j = 2 * d, 2 * d + 1
+        dist[i, j] = dist[j, i] = 10.0
+
+    distances_df = pd.DataFrame(dist, index=names, columns=names)
+    score = replicate_robustness(distances_df)
+
+    assert 0.0 < score < 1.0
+    # Half the samples have replicate at rank 0; the other half at rank n-2.
+    # Mean rank = (n-2)/2; normalised score = 1 - 0.5 = 0.5.
+    assert score == pytest.approx(0.5)

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -165,10 +165,14 @@ def test_knn_prediction_score_reverse_technical_score():
 
 
 REPLICATE_NAMES = [
-    "donor0_a", "donor0_b",
-    "donor1_a", "donor1_b",
-    "donor2_a", "donor2_b",
-    "donor3_a", "donor3_b",
+    "donor0_a",
+    "donor0_b",
+    "donor1_a",
+    "donor1_b",
+    "donor2_a",
+    "donor2_b",
+    "donor3_a",
+    "donor3_b",
 ]
 
 
@@ -176,16 +180,19 @@ REPLICATE_NAMES = [
 def test_replicate_robustness_perfect():
     # Replicate pairs sit at 1; all other donor pairs at 8. Each sample's nearest
     # non-self neighbour is its own replicate.
-    dist = np.array([
-        [0, 1, 8, 8, 8, 8, 8, 8],
-        [1, 0, 8, 8, 8, 8, 8, 8],
-        [8, 8, 0, 1, 8, 8, 8, 8],
-        [8, 8, 1, 0, 8, 8, 8, 8],
-        [8, 8, 8, 8, 0, 1, 8, 8],
-        [8, 8, 8, 8, 1, 0, 8, 8],
-        [8, 8, 8, 8, 8, 8, 0, 1],
-        [8, 8, 8, 8, 8, 8, 1, 0],
-    ], dtype=float)
+    dist = np.array(
+        [
+            [0, 1, 8, 8, 8, 8, 8, 8],
+            [1, 0, 8, 8, 8, 8, 8, 8],
+            [8, 8, 0, 1, 8, 8, 8, 8],
+            [8, 8, 1, 0, 8, 8, 8, 8],
+            [8, 8, 8, 8, 0, 1, 8, 8],
+            [8, 8, 8, 8, 1, 0, 8, 8],
+            [8, 8, 8, 8, 8, 8, 0, 1],
+            [8, 8, 8, 8, 8, 8, 1, 0],
+        ],
+        dtype=float,
+    )
     distances_df = pd.DataFrame(dist, index=REPLICATE_NAMES, columns=REPLICATE_NAMES)
 
     score = replicate_robustness(distances_df)
@@ -197,16 +204,19 @@ def test_replicate_robustness_perfect():
 def test_replicate_robustness_worst():
     # Replicate pairs sit at 8; all other donor pairs at 1. Each sample's own
     # replicate is the farthest non-self neighbour.
-    dist = np.array([
-        [0, 8, 1, 1, 1, 1, 1, 1],
-        [8, 0, 1, 1, 1, 1, 1, 1],
-        [1, 1, 0, 8, 1, 1, 1, 1],
-        [1, 1, 8, 0, 1, 1, 1, 1],
-        [1, 1, 1, 1, 0, 8, 1, 1],
-        [1, 1, 1, 1, 8, 0, 1, 1],
-        [1, 1, 1, 1, 1, 1, 0, 8],
-        [1, 1, 1, 1, 1, 1, 8, 0],
-    ], dtype=float)
+    dist = np.array(
+        [
+            [0, 8, 1, 1, 1, 1, 1, 1],
+            [8, 0, 1, 1, 1, 1, 1, 1],
+            [1, 1, 0, 8, 1, 1, 1, 1],
+            [1, 1, 8, 0, 1, 1, 1, 1],
+            [1, 1, 1, 1, 0, 8, 1, 1],
+            [1, 1, 1, 1, 8, 0, 1, 1],
+            [1, 1, 1, 1, 1, 1, 0, 8],
+            [1, 1, 1, 1, 1, 1, 8, 0],
+        ],
+        dtype=float,
+    )
     distances_df = pd.DataFrame(dist, index=REPLICATE_NAMES, columns=REPLICATE_NAMES)
 
     score = replicate_robustness(distances_df)
@@ -219,16 +229,19 @@ def test_replicate_robustness_intermediate():
     # Donors 0, 1 have tight replicate pairs (distance 1, nearest non-self neighbour).
     # Donors 2, 3 have loose replicate pairs (distance 8, farthest non-self neighbour).
     # All other donor pairs sit at the background distance 4.
-    dist = np.array([
-        [0, 1, 4, 4, 4, 4, 4, 4],
-        [1, 0, 4, 4, 4, 4, 4, 4],
-        [4, 4, 0, 1, 4, 4, 4, 4],
-        [4, 4, 1, 0, 4, 4, 4, 4],
-        [4, 4, 4, 4, 0, 8, 4, 4],
-        [4, 4, 4, 4, 8, 0, 4, 4],
-        [4, 4, 4, 4, 4, 4, 0, 8],
-        [4, 4, 4, 4, 4, 4, 8, 0],
-    ], dtype=float)
+    dist = np.array(
+        [
+            [0, 1, 4, 4, 4, 4, 4, 4],
+            [1, 0, 4, 4, 4, 4, 4, 4],
+            [4, 4, 0, 1, 4, 4, 4, 4],
+            [4, 4, 1, 0, 4, 4, 4, 4],
+            [4, 4, 4, 4, 0, 8, 4, 4],
+            [4, 4, 4, 4, 8, 0, 4, 4],
+            [4, 4, 4, 4, 4, 4, 0, 8],
+            [4, 4, 4, 4, 4, 4, 8, 0],
+        ],
+        dtype=float,
+    )
     distances_df = pd.DataFrame(dist, index=REPLICATE_NAMES, columns=REPLICATE_NAMES)
 
     score = replicate_robustness(distances_df)

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -164,35 +164,29 @@ def test_knn_prediction_score_reverse_technical_score():
     assert relevant_reversed == pytest.approx(relevant_raw)
 
 
-def _make_replicate_distance_matrix(donor_donor: np.ndarray, replicate_distance: float) -> pd.DataFrame:
-    """Build an 8x8 distance DataFrame for 4 donors x 2 replicates.
-
-    ``donor_donor`` is a 4x4 symmetric matrix of inter-donor distances; each donor's
-    two replicates inherit those inter-donor distances and are placed
-    ``replicate_distance`` apart from each other.
-    """
-    n_donors = donor_donor.shape[0]
-    names = [f"donor{d}_{r}" for d in range(n_donors) for r in ("a", "b")]
-    n = len(names)
-    dist = np.zeros((n, n))
-    for i in range(n):
-        for j in range(n):
-            if i == j:
-                continue
-            di = i // 2
-            dj = j // 2
-            if di == dj:
-                dist[i, j] = replicate_distance
-            else:
-                dist[i, j] = donor_donor[di, dj]
-    return pd.DataFrame(dist, index=names, columns=names)
+REPLICATE_NAMES = [
+    "donor0_a", "donor0_b",
+    "donor1_a", "donor1_b",
+    "donor2_a", "donor2_b",
+    "donor3_a", "donor3_b",
+]
 
 
 # Replicate robustness should be 1 when each sample's replicate is its nearest neighbour.
 def test_replicate_robustness_perfect():
-    donor_donor = np.full((4, 4), 1.0)
-    np.fill_diagonal(donor_donor, 0.0)
-    distances_df = _make_replicate_distance_matrix(donor_donor, replicate_distance=0.1)
+    # Replicate pairs sit at 1; all other donor pairs at 8. Each sample's nearest
+    # non-self neighbour is its own replicate.
+    dist = np.array([
+        [0, 1, 8, 8, 8, 8, 8, 8],
+        [1, 0, 8, 8, 8, 8, 8, 8],
+        [8, 8, 0, 1, 8, 8, 8, 8],
+        [8, 8, 1, 0, 8, 8, 8, 8],
+        [8, 8, 8, 8, 0, 1, 8, 8],
+        [8, 8, 8, 8, 1, 0, 8, 8],
+        [8, 8, 8, 8, 8, 8, 0, 1],
+        [8, 8, 8, 8, 8, 8, 1, 0],
+    ], dtype=float)
+    distances_df = pd.DataFrame(dist, index=REPLICATE_NAMES, columns=REPLICATE_NAMES)
 
     score = replicate_robustness(distances_df)
 
@@ -201,9 +195,19 @@ def test_replicate_robustness_perfect():
 
 # Replicate robustness should be 0 when each sample's replicate is its farthest neighbour.
 def test_replicate_robustness_worst():
-    donor_donor = np.full((4, 4), 0.1)
-    np.fill_diagonal(donor_donor, 0.0)
-    distances_df = _make_replicate_distance_matrix(donor_donor, replicate_distance=1.0)
+    # Replicate pairs sit at 8; all other donor pairs at 1. Each sample's own
+    # replicate is the farthest non-self neighbour.
+    dist = np.array([
+        [0, 8, 1, 1, 1, 1, 1, 1],
+        [8, 0, 1, 1, 1, 1, 1, 1],
+        [1, 1, 0, 8, 1, 1, 1, 1],
+        [1, 1, 8, 0, 1, 1, 1, 1],
+        [1, 1, 1, 1, 0, 8, 1, 1],
+        [1, 1, 1, 1, 8, 0, 1, 1],
+        [1, 1, 1, 1, 1, 1, 0, 8],
+        [1, 1, 1, 1, 1, 1, 8, 0],
+    ], dtype=float)
+    distances_df = pd.DataFrame(dist, index=REPLICATE_NAMES, columns=REPLICATE_NAMES)
 
     score = replicate_robustness(distances_df)
 
@@ -212,24 +216,21 @@ def test_replicate_robustness_worst():
 
 # Replicate robustness should fall strictly between 0 and 1 for a mixed configuration.
 def test_replicate_robustness_intermediate():
-    # 4 donors, 2 replicates each. donors 0 and 1 have replicates as nearest neighbours;
-    # donors 2 and 3 have their replicates pushed to the far end of the ranking.
-    names = [f"donor{d}_{r}" for d in range(4) for r in ("a", "b")]
-    n = len(names)
-    dist = np.full((n, n), 1.0)
-    np.fill_diagonal(dist, 0.0)
+    # Donors 0, 1 have tight replicate pairs (distance 1, nearest non-self neighbour).
+    # Donors 2, 3 have loose replicate pairs (distance 8, farthest non-self neighbour).
+    # All other donor pairs sit at the background distance 4.
+    dist = np.array([
+        [0, 1, 4, 4, 4, 4, 4, 4],
+        [1, 0, 4, 4, 4, 4, 4, 4],
+        [4, 4, 0, 1, 4, 4, 4, 4],
+        [4, 4, 1, 0, 4, 4, 4, 4],
+        [4, 4, 4, 4, 0, 8, 4, 4],
+        [4, 4, 4, 4, 8, 0, 4, 4],
+        [4, 4, 4, 4, 4, 4, 0, 8],
+        [4, 4, 4, 4, 4, 4, 8, 0],
+    ], dtype=float)
+    distances_df = pd.DataFrame(dist, index=REPLICATE_NAMES, columns=REPLICATE_NAMES)
 
-    # Tight replicate pairs for donors 0, 1.
-    for d in (0, 1):
-        i, j = 2 * d, 2 * d + 1
-        dist[i, j] = dist[j, i] = 0.05
-
-    # Loose replicate pairs (max distance) for donors 2, 3.
-    for d in (2, 3):
-        i, j = 2 * d, 2 * d + 1
-        dist[i, j] = dist[j, i] = 10.0
-
-    distances_df = pd.DataFrame(dist, index=names, columns=names)
     score = replicate_robustness(distances_df)
 
     assert 0.0 < score < 1.0


### PR DESCRIPTION
The replicate robustness metric was not correctly normalised, this PR fixes it. The metric now has value 1 in the best case (replicates are the closest to each other), and 0 in the worst (all the replicates are the furthest from each other)