### PR TITLE
Fix combat metadata download

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,7 +75,7 @@ jobs:
         with:
           path: ~/.cache/patpy-test-datasets
           # Bump the suffix to invalidate the cache (e.g. when the figshare file ID changes).
-          key: patpy-test-datasets-figshare-64217586-64225884-64225983-64226109-64226097-64291092-v1
+          key: patpy-test-datasets-figshare-64217586-64225884-64225983-64226109-64226097-64291092-v2
       - name: run tests using hatch
         env:
           MPLBACKEND: agg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## 0.16.3
+
+### Fixed
+
+- Downloading COMBAT meta adata did not work due to incorrect link for the programmatic access
+
 ## 0.16.2
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "patpy"
-version = "0.16.2"
+version = "0.16.3"
 description = "A toolbox for patient or sample representation from single-cell data"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/patpy/datasets/_dataloader.py
+++ b/src/patpy/datasets/_dataloader.py
@@ -67,6 +67,12 @@ def _download(  # pragma: no cover
                     head_response.raise_for_status()
                     content_length = int(head_response.headers.get("content-length", 0))
 
+                    if content_length == 0:
+                        logger.warning(
+                            f"Reported content length for {url} is 0 bytes. "
+                            "The file may be empty."
+                        )
+
                     free_space = shutil.disk_usage(output_path).free
                     if content_length > free_space:
                         raise OSError(

--- a/src/patpy/datasets/_dataloader.py
+++ b/src/patpy/datasets/_dataloader.py
@@ -68,10 +68,7 @@ def _download(  # pragma: no cover
                     content_length = int(head_response.headers.get("content-length", 0))
 
                     if content_length == 0:
-                        logger.warning(
-                            f"Reported content length for {url} is 0 bytes. "
-                            "The file may be empty."
-                        )
+                        logger.warning(f"Reported content length for {url} is 0 bytes. The file may be empty.")
 
                     free_space = shutil.disk_usage(output_path).free
                     if content_length > free_space:

--- a/src/patpy/datasets/_datasets.py
+++ b/src/patpy/datasets/_datasets.py
@@ -149,7 +149,7 @@ _DATASET_URLS: dict[str, dict[DatasetKind, str | None]] = {
 }
 
 # Zipped sample-metadata AnnData for the COMBAT cohort (~4 MB).
-_COMBAT_META_URL = "https://figshare.com/ndownloader/files/64291092"
+_COMBAT_META_URL = "https://ndownloader.figshare.com/files/64291092"
 _COMBAT_META_FILENAME = "combat_meta_adata.h5ad"
 
 


### PR DESCRIPTION
Brough up by @VladimirShitov , the following issue appeared with `patpy.datasets.combat(load_metadata=True)`

This is fixed in this PR.

```
---------------------------------------------------------------------------
BadZipFile                                Traceback (most recent call last)
Cell In[3], line 1
----> 1 adata, meta_adata = patpy.datasets.combat(load_metadata=True)

File ~/miniconda3/envs/sample_representation/lib/python3.11/site-packages/patpy/datasets/_datasets.py:257, in combat(kind, overwrite, load_metadata, return_dataset_info)
    255 extras: list[AnnData | DatasetInfo] = []
    256 if load_metadata:
--> 257     extras.append(_load_combat_metadata(overwrite=overwrite))
    258 if return_dataset_info:
    259     extras.append(_COMBAT_INFO)

File ~/miniconda3/envs/sample_representation/lib/python3.11/site-packages/patpy/datasets/_datasets.py:198, in _load_combat_metadata(overwrite)
    196 def _load_combat_metadata(overwrite: bool) -> AnnData:
    197     """Download and return the COMBAT sample-metadata AnnData (~4 MB zipped)."""
--> 198     return _load_dataset(
    199         url=_COMBAT_META_URL,
    200         output_file_name=_COMBAT_META_FILENAME,
    201         overwrite=overwrite,
    202     )

File ~/miniconda3/envs/sample_representation/lib/python3.11/site-packages/patpy/datasets/_datasets.py:166, in _load_dataset(url, output_file_name, overwrite)
    164 if not Path(output_file_path).exists() or overwrite:
    165     zip_name = f"{output_file_name}.zip"
--> 166     _download(
    167         url=url,
    168         output_file_name=zip_name,
    169         output_path=settings.datasetdir,
    170         is_zip=True,
    171     )
    172     (settings.datasetdir / zip_name).unlink(missing_ok=True)
    173 return sc.read_h5ad(output_file_path)

File ~/miniconda3/envs/sample_representation/lib/python3.11/site-packages/patpy/datasets/_dataloader.py:91, in _download(url, output_file_name, output_path, block_size, overwrite, is_zip, timeout, max_retries, retry_delay)
     88 Path(temp_file_name).replace(download_to_path)
     90 if is_zip:
---> 91     with ZipFile(download_to_path, "r") as zip_obj:
     92         zip_obj.extractall(path=output_path)
     93     return Path(output_path)

File ~/miniconda3/envs/sample_representation/lib/python3.11/zipfile.py:1312, in ZipFile.__init__(self, file, mode, compression, allowZip64, compresslevel, strict_timestamps, metadata_encoding)
   1310 try:
   1311     if mode == 'r':
-> 1312         self._RealGetContents()
   1313     elif mode in ('w', 'x'):
   1314         # set the modified flag so central directory gets written
   1315         # even if no files are added to the archive
   1316         self._didModify = True

File ~/miniconda3/envs/sample_representation/lib/python3.11/zipfile.py:1379, in ZipFile._RealGetContents(self)
   1377     raise BadZipFile("File is not a zip file")
   1378 if not endrec:
-> 1379     raise BadZipFile("File is not a zip file")
   1380 if self.debug > 1:
   1381     print(endrec)

BadZipFile: File is not a zip file
```

**Details**
The URL used to download the combat metadata file seems to be blocked by figshare for programmatic access.
The `_download` function now also warns if the `requests.head().headers`' `content-length` is 0, indicating a potentially empty content, which might help to debug future added datasets.

The cache key for the CI in the github actions workflows was updated to ensure the latest URLs are used to download the datasets.