### PR TITLE
Add combat_stephenson and inflammation_atlas datasets to patpy

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,10 @@ on:
     branches: [main]
   schedule:
     - cron: "0 5 1,15 * *"
+  # Manual trigger for the heavy `@pytest.mark.dataset` suite (multi-GB Figshare
+  # downloads). These are not run on PR / push / schedule — opt in by dispatching
+  # this workflow from the Actions tab. See docs/contributing.md.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -70,7 +74,12 @@ jobs:
           python-version: ${{ matrix.env.python }}
       - name: create hatch environment
         run: uvx hatch env create ${{ matrix.env.name }}
+      # Heavy "dataset" tests (multi-GB downloads from Figshare) only run when the
+      # workflow is dispatched manually from the Actions tab — they're too slow
+      # to gate PRs / push-to-main on. Contributors should run them locally when
+      # touching dataset code (see docs/contributing.md).
       - name: Cache test datasets
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/cache@v4
         with:
           path: ~/.cache/patpy-test-datasets
@@ -81,10 +90,11 @@ jobs:
           MPLBACKEND: agg
           PLATFORM: ${{ matrix.os }}
           DISPLAY: :42
+          DATASET_FLAG: ${{ github.event_name == 'workflow_dispatch' && '--run-datasets' || '' }}
         run: |
           export PATPY_TEST_DATASETDIR="$HOME/.cache/patpy-test-datasets"
           mkdir -p "$PATPY_TEST_DATASETDIR"
-          uvx hatch run ${{ matrix.env.name }}:run-cov -v --color=yes -n auto --run-datasets
+          uvx hatch run ${{ matrix.env.name }}:run-cov -v --color=yes -n auto $DATASET_FLAG
       - name: generate coverage report
         run: |
           # See https://coverage.readthedocs.io/en/latest/config.html#run-patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning][].
 
 - Turn off running dataset tests manually, they can now only be triggered manually
 
+### Fixed
+
+- Add locking scanpy test file to prevent concurrent reading and failing tests: https://github.com/scverse/scanpy/issues/4097
+
 ## 0.16.3
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## 0.16.4
+
+### Added
+
+- `patpy.datasets.combat_stephenson`: harmonized COMBAT + Stephenson COVID-19 PBMC cohort (251 samples / 1,399,435 cells / 1,856 genes) with shared cell_coarse_aligned annotations and joint PCA/scVI/scANVI embeddings.
+- `patpy.datasets.inflammation_atlas`: inflammation atlas cross-study dataset. Added only scANVI latents. 3 splits (main / external / validation) selected through a split argument, each with its own DatasetInfo (cell_type_key is Level1 for main, Level1pred for external/validation).
+
 ## 0.16.3
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning][].
 - `patpy.datasets.combat_stephenson`: harmonized COMBAT + Stephenson COVID-19 PBMC cohort (251 samples / 1,399,435 cells / 1,856 genes) with shared cell_coarse_aligned annotations and joint PCA/scVI/scANVI embeddings.
 - `patpy.datasets.inflammation_atlas`: inflammation atlas cross-study dataset. Added only scANVI latents. 3 splits (main / external / validation) selected through a split argument, each with its own DatasetInfo (cell_type_key is Level1 for main, Level1pred for external/validation).
 
+### Changed
+
+- Turn off running dataset tests manually, they can now only be triggered manually
+
 ## 0.16.3
 
 ### Fixed

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -238,10 +238,56 @@ in the root of the repository.
 
 [pytest]: https://docs.pytest.org/
 
+### Heavy dataset tests
+
+Tests marked with `@pytest.mark.dataset` download real datasets from Figshare (multi-GB) and are **skipped by default** — both locally and on every automatic CI run (PR, push to `main`, scheduled cron) — so day-to-day test runs stay fast. On CI they only run when the `Test` workflow is **dispatched manually** from the Actions tab (the `workflow_dispatch` trigger). Trigger one after changes to `src/patpy/datasets/`, or whenever you want to re-validate the Figshare downloads.
+
+If you change anything in `src/patpy/datasets/` (or otherwise want to validate the downloads) locally, opt in with `--run-datasets`:
+
+:::::{tabs}
+::::{group-tab} Hatch
+
+```bash
+hatch test -- --run-datasets
+```
+
+::::
+
+::::{group-tab} uv
+
+```bash
+uv run pytest --run-datasets
+```
+
+::::
+
+::::{group-tab} Pip
+
+```bash
+source .venv/bin/activate
+pytest --run-datasets
+```
+
+::::
+:::::
+
+To avoid re-downloading on every run, point pytest at a persistent cache directory by exporting `PATPY_TEST_DATASETDIR`:
+
+```bash
+export PATPY_TEST_DATASETDIR="$HOME/.cache/patpy-test-datasets"
+mkdir -p "$PATPY_TEST_DATASETDIR"
+pytest --run-datasets -k test_combat   # for example
+```
+
+You can also restrict the run to a single dataset loader with `-k` (e.g. `-k test_inflammation_atlas`) so you don't have to wait for every dataset to download.
+
 ### Continuous integration
 
 Continuous integration via GitHub actions will automatically run the tests on all pull requests and test
-against the minimum and maximum supported Python version.
+against the minimum and maximum supported Python version. Heavy `@pytest.mark.dataset` tests are skipped
+on every automatic run (PR, push to `main`, scheduled cron) — they would otherwise time out downloading
+multi-GB files. To run them on CI, dispatch the `Test` workflow manually from the Actions tab; see
+[Heavy dataset tests](#heavy-dataset-tests) above for the local opt-in workflow.
 
 Additionally, there’s a CI job that tests against pre-releases of all dependencies (if there are any).
 The purpose of this check is to detect incompatibilities of new package versions early on and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ optional-dependencies.scpoli = [
 ]
 optional-dependencies.test = [
   "coverage",
+  "filelock",       # cross-worker lock for pytest-xdist (scanpy download race)
   "pytest",
   "pytest-cov",
 ]
@@ -120,6 +121,7 @@ dev = [
 ]
 test = [
   "coverage>=7.10",
+  "filelock",       # cross-worker lock for pytest-xdist (scanpy download race)
   "pytest",
   "pytest-cov",     # For VS Code’s coverage functionality
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ optional-dependencies.scpoli = [
 ]
 optional-dependencies.test = [
   "coverage",
-  "filelock",       # cross-worker lock for pytest-xdist (scanpy download race)
+  "filelock",   # cross-worker lock for pytest-xdist (scanpy download race)
   "pytest",
   "pytest-cov",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "patpy"
-version = "0.16.3"
+version = "0.16.4"
 description = "A toolbox for patient or sample representation from single-cell data"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/patpy/datasets/__init__.py
+++ b/src/patpy/datasets/__init__.py
@@ -1,7 +1,9 @@
 from ._datasets import (
     DatasetInfo,
     combat,
+    combat_stephenson,
     hlca,
+    inflammation_atlas,
     onek1k,
     stephenson,
     ticatlas,
@@ -11,8 +13,10 @@ from .synthetic import covid_19_hallmarks, process_adata, simulate_data
 __all__ = [
     "DatasetInfo",
     "combat",
+    "combat_stephenson",
     "covid_19_hallmarks",
     "hlca",
+    "inflammation_atlas",
     "onek1k",
     "process_adata",
     "simulate_data",

--- a/src/patpy/datasets/_datasets.py
+++ b/src/patpy/datasets/_datasets.py
@@ -9,6 +9,7 @@ from patpy._settings import settings
 from patpy.datasets._dataloader import _download
 
 DatasetKind = Literal["raw", "processed"]
+InflammationAtlasSplit = Literal["main", "external", "validation"]
 
 
 @dataclass(frozen=True)
@@ -123,6 +124,70 @@ _TICATLAS_INFO = DatasetInfo(
     sample_metadata_columns=["patient", "gender", "subtype", "source"],
 )
 
+_COMBAT_STEPHENSON_INFO = DatasetInfo(
+    n_samples=251,
+    n_cells=1399435,
+    n_features=1856,
+    sample_key="sample_id",
+    cell_type_key="cell_coarse_aligned",
+    sample_metadata_columns=[
+        "dataset",
+        "Site",
+        "SARSCoV2PCR",
+        "Outcome",
+        "TimeSinceOnset",
+        "split",
+        "Status",
+        "severity_ord",
+        "severity_idx",
+        "outcome_bin",
+        "Status_encoded",
+    ],
+)
+
+# Per-split metadata for the inflammation atlas. All three splits are
+# latents-only (n_features=0; the 30-dim scANVI embedding lives in
+# obsm['X_scANVI_atlas']). Main carries ground-truth Level1/Level2 annotations;
+# external and validation carry model-predicted Level1pred/Level2pred labels.
+_INFLAMMATION_ATLAS_SAMPLE_METADATA_COLUMNS = [
+    "studyID",
+    "chemistry",
+    "technology",
+    "disease",
+    "sex",
+    "binned_age",
+    "disease_group",
+    "therapy_response",
+    "smoking_status",
+]
+
+_INFLAMMATION_ATLAS_INFOS: dict[InflammationAtlasSplit, DatasetInfo] = {
+    "main": DatasetInfo(
+        n_samples=817,
+        n_cells=4918140,
+        n_features=0,
+        sample_key="sampleID",
+        cell_type_key="Level1",
+        sample_metadata_columns=_INFLAMMATION_ATLAS_SAMPLE_METADATA_COLUMNS,
+    ),
+    "external": DatasetInfo(
+        n_samples=86,
+        n_cells=572872,
+        n_features=0,
+        sample_key="sampleID",
+        cell_type_key="Level1pred",
+        sample_metadata_columns=_INFLAMMATION_ATLAS_SAMPLE_METADATA_COLUMNS,
+    ),
+    "validation": DatasetInfo(
+        n_samples=144,
+        n_cells=849922,
+        n_features=0,
+        sample_key="sampleID",
+        cell_type_key="Level1pred",
+        sample_metadata_columns=_INFLAMMATION_ATLAS_SAMPLE_METADATA_COLUMNS,
+    ),
+}
+
 # Registry of Figshare URLs for each dataset / kind. ``None`` means "not yet
 # uploaded"; the loader will raise NotImplementedError for those combinations.
 _DATASET_URLS: dict[str, dict[DatasetKind, str | None]] = {
@@ -144,6 +209,22 @@ _DATASET_URLS: dict[str, dict[DatasetKind, str | None]] = {
     },
     "ticatlas": {
         "processed": "https://ndownloader.figshare.com/files/64226097",
+        "raw": None,
+    },
+    "combat_stephenson": {
+        "processed": "https://ndownloader.figshare.com/files/64486770",
+        "raw": None,
+    },
+    "inflammation_atlas_main": {
+        "processed": "https://ndownloader.figshare.com/files/64486761",
+        "raw": None,
+    },
+    "inflammation_atlas_external": {
+        "processed": "https://ndownloader.figshare.com/files/64486752",
+        "raw": None,
+    },
+    "inflammation_atlas_validation": {
+        "processed": "https://ndownloader.figshare.com/files/64486758",
         "raw": None,
     },
 }
@@ -436,4 +517,126 @@ def ticatlas(
     adata = _load_named_dataset("ticatlas", kind=kind, overwrite=overwrite)
     if return_dataset_info:
         return adata, _TICATLAS_INFO
+    return adata
+
+
+def combat_stephenson(
+    kind: DatasetKind = "processed",
+    overwrite: bool = False,
+    return_dataset_info: bool = False,
+) -> AnnData | tuple[AnnData, DatasetInfo]:
+    """Harmonized COMBAT + Stephenson COVID-19 PBMC dataset.
+
+    Cross-study harmonization of the COMBAT and Stephenson COVID-19 PBMC cohorts
+    sharing a unified cell-type annotation (``cell_coarse_aligned``) and joint
+    PCA/scVI/scANVI embeddings (in ``adata.obsm``). The published file
+    contains 1,399,435 cells across 251 samples (2 source datasets), with 1,856
+    genes retained after harmonization. Raw counts are kept under
+    ``adata.layers['X_raw_counts']``. Sample-level metadata (Site, Status,
+    severity, outcome, etc.) is available in ``adata.obs`` directly.
+
+    Parameters
+    ----------
+    kind
+        Either ``"processed"`` (default) or ``"raw"``. The processed dataset is
+        available via Figshare; ``"raw"`` currently raises
+        :class:`NotImplementedError`.
+    overwrite
+        If ``True``, re-download the dataset even when a cached copy exists.
+    return_dataset_info
+        If ``True``, return a tuple ``(adata, DatasetInfo)`` instead of just ``adata``.
+
+    References
+    ----------
+        Ahern, D. J., et al. (2022). A blood atlas of COVID-19 defines hallmarks of disease severity and specificity. Cell, 185(5), 916-938. https://doi.org/10.1016/j.cell.2022.01.012
+        Stephenson, E., et al. (2021). Single-cell multi-omics analysis of the immune response in COVID-19. Nature medicine, 27(5), 904-916. https://doi.org/10.1038/s41591-021-01329-2
+
+    Returns
+    -------
+        :class:`~anndata.AnnData` object of scRNA-seq profiles, optionally paired
+        with a :class:`DatasetInfo` describing the dataset's standard schema.
+
+    Examples
+    --------
+        >>> import patpy
+        >>> adata = patpy.datasets.combat_stephenson()
+        >>> adata, info = patpy.datasets.combat_stephenson(return_dataset_info=True)
+    """
+    adata = _load_named_dataset("combat_stephenson", kind=kind, overwrite=overwrite)
+    if return_dataset_info:
+        return adata, _COMBAT_STEPHENSON_INFO
+    return adata
+
+
+def inflammation_atlas(
+    split: InflammationAtlasSplit = "main",
+    kind: DatasetKind = "processed",
+    overwrite: bool = False,
+    return_dataset_info: bool = False,
+) -> AnnData | tuple[AnnData, DatasetInfo]:
+    """Cross-study inflammation atlas (scANVI latents).
+
+    The published "processed" version is a scANVI-embedded latents-only
+    :class:`~anndata.AnnData` with the 30-dimensional scANVI embedding under
+    ``adata.obsm['X_scANVI_atlas']``. The file has no gene-expression matrix
+    for now; use the embedding directly for
+    sample-representation workflows. Sample-level metadata (``studyID``,
+    ``chemistry``, ``disease``, ``sex``, ``binned_age``) is available in
+    ``adata.obs`` directly.
+
+    Three splits are exposed via the ``split`` argument:
+
+    * ``"main"`` (default) — atlas training data, 4,918,140 cells / 817 samples,
+      with ground-truth ``Level1`` / ``Level2`` cell-type annotations.
+    * ``"external"`` — held-out studies, 572,872 cells /
+      86 samples, with model-predicted ``Level1pred`` / ``Level2pred`` labels.
+    * ``"validation"`` — held-out samples, 849,922 cells /
+      144 samples, with model-predicted ``Level1pred`` / ``Level2pred`` labels.
+
+    Parameters
+    ----------
+    split
+        Which split to load: ``"main"``, ``"external"``, or ``"validation"``.
+        Defaults to ``"main"``.
+    kind
+        Either ``"processed"`` (default) or ``"raw"``. The processed splits are
+        available via Figshare; ``"raw"`` currently raises
+        :class:`NotImplementedError`.
+    overwrite
+        If ``True``, re-download the dataset even when a cached copy exists.
+    return_dataset_info
+        If ``True``, return a tuple ``(adata, DatasetInfo)`` instead of just
+        ``adata``. The :class:`DatasetInfo` is split-specific: ``cell_type_key``
+        is ``"Level1"`` for ``main`` and ``"Level1pred"`` for the other two
+        splits. ``n_features`` is reported as ``0`` because the file is
+        latents-only.
+
+        
+    References
+    ----------
+       Jiménez-Gracia, L., Maspero, D., Aguilar-Fernández, S. et al. Interpretable inflammation landscape of circulating immune cells. Nat Med 32, 633–644 (2026). https://doi.org/10.1038/s41591-025-04126-3
+
+        
+    Returns
+    -------
+        :class:`~anndata.AnnData` object with scANVI latents under
+        ``obsm['X_scANVI_atlas']``, optionally paired with a :class:`DatasetInfo`
+        describing the requested split's standard schema.
+
+    Examples
+    --------
+        >>> import patpy
+        >>> adata = patpy.datasets.inflammation_atlas()
+        >>> latents = adata.obsm["X_scANVI_atlas"]
+        >>> adata, info = patpy.datasets.inflammation_atlas(return_dataset_info=True)
+        >>> ext = patpy.datasets.inflammation_atlas(split="external")
+        >>> val = patpy.datasets.inflammation_atlas(split="validation")
+    """
+    if split not in _INFLAMMATION_ATLAS_INFOS:
+        raise ValueError(
+            f"split must be one of {tuple(_INFLAMMATION_ATLAS_INFOS)}, got {split!r}."
+        )
+    adata = _load_named_dataset(f"inflammation_atlas_{split}", kind=kind, overwrite=overwrite)
+    if return_dataset_info:
+        return adata, _INFLAMMATION_ATLAS_INFOS[split]
     return adata

--- a/src/patpy/datasets/_datasets.py
+++ b/src/patpy/datasets/_datasets.py
@@ -611,12 +611,12 @@ def inflammation_atlas(
         splits. ``n_features`` is reported as ``0`` because the file is
         latents-only.
 
-        
+
     References
     ----------
        Jiménez-Gracia, L., Maspero, D., Aguilar-Fernández, S. et al. Interpretable inflammation landscape of circulating immune cells. Nat Med 32, 633–644 (2026). https://doi.org/10.1038/s41591-025-04126-3
 
-        
+
     Returns
     -------
         :class:`~anndata.AnnData` object with scANVI latents under
@@ -633,9 +633,7 @@ def inflammation_atlas(
         >>> val = patpy.datasets.inflammation_atlas(split="validation")
     """
     if split not in _INFLAMMATION_ATLAS_INFOS:
-        raise ValueError(
-            f"split must be one of {tuple(_INFLAMMATION_ATLAS_INFOS)}, got {split!r}."
-        )
+        raise ValueError(f"split must be one of {tuple(_INFLAMMATION_ATLAS_INFOS)}, got {split!r}.")
     adata = _load_named_dataset(f"inflammation_atlas_{split}", kind=kind, overwrite=overwrite)
     if return_dataset_info:
         return adata, _INFLAMMATION_ATLAS_INFOS[split]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,20 +95,42 @@ def nan_heavy_matrix():
 
 
 @pytest.fixture(scope="session")
-def pbmc3k_adata():
+def pbmc3k_adata(request, tmp_path_factory):
     """Preprocessed PBMC3k dataset with randomly assigned sample labels.
 
     Provides real single-cell data with X_pca embedding and louvain cell-type
     annotations, suitable for methods that require biological structure in the
     data (e.g. DiffusionEMD, GloScope, WassersteinTSNE, PILOT, MOFA).
+
+    Under pytest-xdist each worker runs its own session fixture, so without a
+    cross-process lock multiple workers race on scanpy's shared
+    ``pbmc3k_processed.h5ad`` download and one ends up reading a partially
+    written file (``OSError: ... truncated file``). The filelock pattern below
+    is the one recommended in the pytest-xdist docs.
     """
     import scanpy as sc
 
-    adata = sc.datasets.pbmc3k_processed()
-    rng = np.random.default_rng(0)
-    n_samples = 4
-    adata.obs["sample_id"] = rng.choice([f"sample_{i}" for i in range(n_samples)], size=adata.n_obs).astype(str)
-    return adata
+    def _load() -> AnnData:
+        adata = sc.datasets.pbmc3k_processed()
+        rng = np.random.default_rng(0)
+        n_samples = 4
+        adata.obs["sample_id"] = rng.choice([f"sample_{i}" for i in range(n_samples)], size=adata.n_obs).astype(str)
+        return adata
+
+    # Detect xdist via its ``worker_id`` fixture. Without xdist (or its plugin
+    # not installed), no cross-worker race is possible, so just load directly.
+    try:
+        worker_id = request.getfixturevalue("worker_id")
+    except pytest.FixtureLookupError:
+        return _load()
+    if worker_id == "master":
+        return _load()
+
+    from filelock import FileLock
+
+    lock_path = tmp_path_factory.getbasetemp().parent / "pbmc3k_processed.lock"
+    with FileLock(str(lock_path)):
+        return _load()
 
 
 @pytest.fixture

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -138,6 +138,56 @@ def test_ticatlas(tmp_path):
         patpy.settings.datasetdir = original
 
 
+@pytest.mark.dataset
+def test_combat_stephenson(tmp_path):
+    original = patpy.settings.datasetdir
+    patpy.settings.datasetdir = _datasetdir(tmp_path)
+    try:
+        adata = patpy.datasets.combat_stephenson()
+
+        assert isinstance(adata, AnnData)
+        assert adata.n_obs == 1399435
+        assert adata.n_vars == 1856
+        assert "X_raw_counts" in adata.layers
+
+        adata, info = patpy.datasets.combat_stephenson(return_dataset_info=True)
+        _check_dataset_info(adata, info)
+    finally:
+        patpy.settings.datasetdir = original
+
+
+@pytest.mark.dataset
+@pytest.mark.parametrize(
+    ("split", "n_obs", "n_samples"),
+    [
+        ("main", 4918140, 817),
+        ("external", 572872, 86),
+        ("validation", 849922, 144),
+    ],
+)
+def test_inflammation_atlas(tmp_path, split, n_obs, n_samples):
+    original = patpy.settings.datasetdir
+    patpy.settings.datasetdir = _datasetdir(tmp_path)
+    try:
+        adata = patpy.datasets.inflammation_atlas(split=split)
+
+        assert isinstance(adata, AnnData)
+        assert adata.n_obs == n_obs
+        assert adata.n_vars == 0
+        assert "X_scANVI_atlas" in adata.obsm
+
+        adata, info = patpy.datasets.inflammation_atlas(split=split, return_dataset_info=True)
+        assert info.n_samples == n_samples
+        _check_dataset_info(adata, info)
+    finally:
+        patpy.settings.datasetdir = original
+
+
+def test_inflammation_atlas_invalid_split():
+    with pytest.raises(ValueError):
+        patpy.datasets.inflammation_atlas(split="banana")  # type: ignore[arg-type]
+
+
 @pytest.mark.parametrize(
     "loader",
     [
@@ -146,6 +196,8 @@ def test_ticatlas(tmp_path):
         patpy.datasets.onek1k,
         patpy.datasets.stephenson,
         patpy.datasets.ticatlas,
+        patpy.datasets.combat_stephenson,
+        patpy.datasets.inflammation_atlas,
     ],
 )
 def test_kind_raw_not_implemented(loader):


### PR DESCRIPTION
Add two new dataset entry points to patpy.datasets:

- combat_stephenson: harmonized COMBAT + Stephenson COVID-19 PBMC cohort (251 samples / 1,399,435 cells / 1,856 genes) with shared cell_coarse_aligned annotations and joint PCA/scVI/scANVI embeddings.
- inflammation_atlas: cross-study scANVI latents-only atlas exposed via three splits (main / external / validation) selected through a split argument, each with its own DatasetInfo (cell_type_key is Level1 for main, Level1pred for external/validation).

Wires up Figshare download URLs for all four files and re-exports the new loaders from patpy.datasets.