### PR TITLE
fix SampleCLR.samples to cover all donors, not just train split

### DIFF
--- a/src/patpy/tl/supervised.py
+++ b/src/patpy/tl/supervised.py
@@ -2575,7 +2575,7 @@ class SampleCLR(SupervisedSampleMethod):
             **extra_kwargs,
         )
 
-        self.samples = np.array(self._sclr_model.train_dataset.unique_categories)
+        self.samples = np.array(self._sclr_model.metadata_all.index.values)
 
         if pretrain:
             self.pretrain(


### PR DESCRIPTION
## Summary

- `SampleCLR.prepare_anndata` was setting `self.samples = self._sclr_model.train_dataset.unique_categories`, which silently dropped val/test donors from `get_sample_representations`, `predict`, `get_sample_importance`, and `get_cell_importance` whenever the user passed `train_ids` / `val_ids` / `test_ids` into `ContrastiveModel` via `model_kwargs`.
- Other `SupervisedSampleMethod` subclasses (MixMIL, PULSAR, PaSCient) already key `self.samples` on the full donor set — this aligns SampleCLR with that contract.
- The `ContrastiveModel`'s internal train/val/test split is untouched: it lives in `self._sclr_model.{train,val,test}_dataset` and is never touched by patpy's `self.samples`. Pretrain, native fine-tune, validation eval, and early stopping are all unaffected.
- One-line change: `self.samples = np.array(self._sclr_model.metadata_all.index.values)`.

## Behaviour change

`get_sample_representations` / `predict` / `get_sample_importance` / `get_cell_importance` now return rows for **all** donors (train + val + test). Previously they silently returned train-only.

A stale `adata.uns["supervised_sample_importance"]` cache from a pre-fix run will trigger a shape mismatch on the next `get_sample_importance` call — recompute with `force=True` or `del adata.uns["supervised_sample_importance"]`.

## Test plan

- [ ] Run a SampleCLR fit with explicit `train_ids` / `val_ids` / `test_ids`; confirm `get_sample_representations().index` covers all three sets.
- [ ] Confirm `predict(label)` returns predictions for val/test donors that were previously dropped.
- [ ] Confirm a fit *without* explicit splits (i.e. `train_ids=None`) still behaves identically — `metadata_all.index` equals `train_dataset.unique_categories` in that case.
- [ ] Confirm sklearn-probe fallback (`fine_tune` with a new label) still fits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)