### PR TITLE
Download datasets with Pooch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,13 @@ dependencies = [
   "anndata>=0.8",
   "ehrapy",
   "gudhi",
+  "ipywidgets",
   "matplotlib>=3.6",
   "numpy>=1.23",
   "opentsne>=0.6",
   "pandas>=1.5",
   "plottable",
+  "pooch",
   "scipy>=1.10",
   "seaborn>=0.12",
 ]

--- a/src/patpy/datasets/_dataloader.py
+++ b/src/patpy/datasets/_dataloader.py
@@ -1,21 +1,49 @@
 import logging
-import shutil
 import tempfile
-import time
 from pathlib import Path
-from random import choice
-from string import ascii_lowercase
 from zipfile import ZipFile
 
-import requests
-from filelock import FileLock
-from requests.exceptions import RequestException
-from tqdm import tqdm
+import pooch
+from rich.progress import Progress, TaskID
 
 logger = logging.getLogger(__name__)
 
+pooch.get_logger().setLevel(logging.WARNING)
 
-# from pertpy: https://github.com/scverse/pertpy/blob/ac988bc924d653879a755a18dcc389fea89e54bc/pertpy/data/_dataloader.py#L1
+
+class _RichProgress:
+    """Adapter exposing the tqdm-like interface pooch expects, backed by rich.progress."""
+
+    def __init__(self, description: str = "[red]Downloading..."):
+        self._description = description
+        self._progress: Progress | None = None
+        self._task: TaskID | None = None
+        self.total: int | None = None
+
+    def _ensure_started(self) -> None:
+        if self._progress is None:
+            self._progress = Progress(refresh_per_second=3)
+            self._progress.start()
+            self._task = self._progress.add_task(self._description, total=self.total or None)
+
+    def update(self, n: int) -> None:
+        self._ensure_started()
+        if self.total is not None and self._progress.tasks[self._task].total != self.total:
+            self._progress.update(self._task, total=self.total or None)
+        self._progress.update(self._task, advance=n)
+
+    def reset(self) -> None:
+        self._ensure_started()
+        self._progress.reset(self._task, total=self.total or None)
+
+    def close(self) -> None:
+        if self._progress is not None:
+            self._progress.stop()
+            self._progress = None
+            self._task = None
+
+
+# from pertpy: https://github.com/scverse/pertpy/blob/main/pertpy/data/_dataloader.py
 def _download(  # pragma: no cover
     url: str,
     output_file_name: str | None = None,
@@ -27,97 +55,47 @@ def _download(  # pragma: no cover
     max_retries: int = 3,
     retry_delay: int = 5,
 ) -> Path:
-    """Downloads a dataset irrespective of the format.
+    """Download a dataset via pooch with a rich progress bar.
 
     Args:
-        url: URL to download
-        output_file_name: Name of the downloaded file
-        output_path: Path to download/extract the files to.
-        block_size: Block size for downloads in bytes.
-        overwrite: Whether to overwrite existing files.
-        is_zip: Whether the downloaded file needs to be unzipped.
-        timeout: Request timeout in seconds.
-        max_retries: Maximum number of retry attempts.
-        retry_delay: Delay between retries in seconds.
-    """
-    if output_file_name is None:
-        letters = ascii_lowercase
-        output_file_name = f"patpy_tmp_{''.join(choice(letters) for _ in range(10))}"
+        url: URL to download.
+        output_file_name: Name of the downloaded file. Inferred from the URL if not provided.
+        output_path: Directory to download/extract the files to. Defaults to the system temp dir.
+        block_size: Chunk size for the HTTP stream in bytes.
+        overwrite: Whether to overwrite an existing file.
+        is_zip: Whether the downloaded archive should be extracted into `output_path`.
+        timeout: Per-request timeout in seconds.
 
+    Returns:
+        The path of the downloaded file, or `output_path` if `is_zip` is True.
+    """
     if output_path is None:
         output_path = tempfile.gettempdir()
+    output_path = Path(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
 
-    download_to_path = Path(output_path) / output_file_name
+    if output_file_name is None:
+        output_file_name = url.rsplit("/", 1)[-1]
 
-    Path(output_path).mkdir(parents=True, exist_ok=True)
-    lock_path = Path(output_path) / f"{output_file_name}.lock"
+    target = output_path / output_file_name
+    if overwrite and target.exists():
+        target.unlink()
 
-    try:
-        with FileLock(lock_path, timeout=300):
-            if Path(download_to_path).exists() and not overwrite:
-                logger.warning(f"File {download_to_path} already exists!")
-                return download_to_path
+    pooch.retrieve(
+        url=url,
+        known_hash=None,
+        fname=output_file_name,
+        path=str(output_path),
+        downloader=pooch.HTTPDownloader(
+            progressbar=_RichProgress(),
+            chunk_size=block_size,
+            timeout=timeout,
+        ),
+    )
 
-            temp_file_name = Path(f"{download_to_path}.part")
+    if is_zip:
+        with ZipFile(target, "r") as zip_obj:
+            zip_obj.extractall(path=output_path)
+        return output_path
 
-            retry_count = 0
-            while retry_count <= max_retries:
-                try:
-                    head_response = requests.head(url, timeout=timeout)
-                    head_response.raise_for_status()
-                    content_length = int(head_response.headers.get("content-length", 0))
-
-                    if content_length == 0:
-                        logger.warning(f"Reported content length for {url} is 0 bytes. The file may be empty.")
-
-                    free_space = shutil.disk_usage(output_path).free
-                    if content_length > free_space:
-                        raise OSError(
-                            f"Insufficient disk space. Need {content_length} bytes, but only {free_space} available."
-                        )
-
-                    response = requests.get(url, stream=True)
-                    response.raise_for_status()
-                    total = int(response.headers.get("content-length", 0))
-
-                    with (
-                        tqdm(total=total, unit="B", unit_scale=True, desc="Downloading") as progress,
-                        Path(temp_file_name).open("wb") as file,
-                    ):
-                        for data in response.iter_content(block_size):
-                            file.write(data)
-                            progress.update(len(data))
-
-                    Path(temp_file_name).replace(download_to_path)
-
-                    if is_zip:
-                        with ZipFile(download_to_path, "r") as zip_obj:
-                            zip_obj.extractall(path=output_path)
-                        return Path(output_path)
-
-                    return download_to_path
-                except (OSError, RequestException) as e:
-                    retry_count += 1
-                    if retry_count <= max_retries:
-                        logger.warning(
-                            f"Download attempt {retry_count}/{max_retries} failed: {str(e)}. Retrying in {retry_delay} seconds..."
-                        )
-                        time.sleep(retry_delay)
-                    else:
-                        logger.error(f"Download failed after {max_retries} attempts: {str(e)}")
-                        if Path(temp_file_name).exists():
-                            Path(temp_file_name).unlink(missing_ok=True)
-                        raise
-
-                except Exception as e:
-                    logger.error(f"Download failed: {str(e)}")
-                    if Path(temp_file_name).exists():
-                        Path(temp_file_name).unlink(missing_ok=True)
-                    raise
-                finally:
-                    if Path(temp_file_name).exists():
-                        Path(temp_file_name).unlink(missing_ok=True)
-    finally:
-        lock_path.unlink(missing_ok=True)
-
-    return Path(download_to_path)
+    return target

--- a/src/patpy/datasets/_dataloader.py
+++ b/src/patpy/datasets/_dataloader.py
@@ -66,7 +66,8 @@ def _download(  # pragma: no cover
         is_zip: Whether the downloaded archive should be extracted into `output_path`.
         timeout: Per-request timeout in seconds.
 
-    Returns:
+    Returns
+    -------
         The path of the downloaded file, or `output_path` if `is_zip` is True.
     """
     if output_path is None:


### PR DESCRIPTION
`pooch` makes downloading datasets easier.

`pertpy`, from which the original download was inspired, also very recently transitioned to using `pooch`: https://github.com/scverse/pertpy/pull/980

Outside of the download functions, nothing changes.

Added the nice download progress bar which pertpy shows, too.