### PR TITLE
Extending regression training and evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## 0.16.7
+
+### Added
+
+- `patpy.tl.evaluate_regression(y_true, y_pred)`: general-purpose regression metrics (`r2`, `spearman`, `pearson`, `mae`, `n`) for any predicted/true vectors, with non-finite masking and `NaN` when fewer than three valid pairs remain.
+- `PaSCient` regression support: `tasks=["regression"]` trains a per-view MSE head with automatic target standardisation, enabling continuous donor-level targets (e.g. age) instead of only classification.
+- `BaseSampleMethod.fit_linear_probe(..., store=True)` registers the fitted probe in `self._probes` so `predict()` can serve it afterwards — e.g. attaching a continuous-regression head on top of a classification-only model such as `MixMIL`.
+
+### Changed
+
+- `fit_linear_probe` now also works for sample-representation methods whose embedding is a plain ndarray or is computed lazily (via `calculate_distance_matrix`), tolerates an empty test set (train on all samples, for a transferable probe), and returns `spearman` and `mae` alongside `r2`/`pearson` for regression.
+- Supervised `predict()` resolves probe-backed labels through a shared `_predict_with_probe`; `MixMIL.predict` uses a stored regression probe when one is present, so a continuous target can ride on top of its binomial head.
+
 ## 0.16.6
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning][].
 
 ### Changed
 
-- `fit_linear_probe` now also works for sample-representation methods whose embedding is a plain ndarray or is computed lazily (via `calculate_distance_matrix`), tolerates an empty test set (train on all samples, for a transferable probe), and returns `spearman` and `mae` alongside `r2`/`pearson` for regression.
+- `fit_linear_probe` now also works for sample-representation methods whose embedding is a plain ndarray or is computed lazily (via `calculate_distance_matrix`), accepts an empty test set to train on all samples (returning metrics on the train set, with a new `evaluated_on` key reporting `"test"`/`"train"`), and returns `spearman` and `mae` alongside `r2`/`pearson` for regression.
 - Supervised `predict()` resolves probe-backed labels through a shared `_predict_with_probe`; `MixMIL.predict` uses a stored regression probe when one is present, so a continuous target can ride on top of its binomial head.
 
 ## 0.16.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning][].
 - `fit_linear_probe` now also works for sample-representation methods whose embedding is a plain ndarray or is computed lazily (via `calculate_distance_matrix`), accepts an empty test set to train on all samples (returning metrics on the train set, with a new `evaluated_on` key reporting `"test"`/`"train"`), and returns `spearman` and `mae` alongside `r2`/`pearson` for regression.
 - Supervised `predict()` resolves probe-backed labels through a shared `_predict_with_probe`; `MixMIL.predict` uses a stored regression probe when one is present, so a continuous target can ride on top of its binomial head.
 
+### Fixed
+
+- `MixMIL.get_sample_representations` now indexes the embedding by the donor order produced by `_build_bags` rather than `self.samples`, so labels stay matched to embeddings when the model is re-pointed at a new cohort.
+- `fit_linear_probe` recomputes the representation from the current `adata` for supervised methods instead of reusing a cached one, preventing a stale cross-cohort representation from corrupting the probe.
+- `_move_layer_to_X` skips the `None` layer key (newer AnnData exposes `X` as `layers[None]`), fixing an `AnnData` construction error on recent anndata versions.
+
 ## 0.16.6
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "patpy"
-version = "0.16.6"
+version = "0.16.7"
 description = "A toolbox for patient or sample representation from single-cell data"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/patpy/tl/__init__.py
+++ b/src/patpy/tl/__init__.py
@@ -7,6 +7,7 @@ from .condition_comparison import (
 from .evaluation import (
     associate_embedding_with_covariates,
     evaluate_prediction,
+    evaluate_regression,
     evaluate_representation,
     persistence_evaluation,
     predict_knn,

--- a/src/patpy/tl/_base_sample_method.py
+++ b/src/patpy/tl/_base_sample_method.py
@@ -357,6 +357,32 @@ class BaseSampleMethod:
 
         return axes
 
+    def _get_sample_representation_frame(self) -> "pd.DataFrame":
+        """Return the sample representation as a DataFrame indexed by sample.
+
+        Works for every method flavour: representation methods set
+        :attr:`sample_representation` directly (sometimes as a plain ndarray),
+        while supervised methods may only expose it lazily through
+        :meth:`get_sample_representations`. An ndarray is wrapped using
+        :attr:`samples` as the index.
+        """
+        rep = self.sample_representation
+        if rep is None and hasattr(self, "get_sample_representations"):
+            rep = self.get_sample_representations()
+        if rep is None and hasattr(self, "calculate_distance_matrix"):
+            # Representation methods (e.g. Pseudobulk) populate sample_representation
+            # lazily when the distance matrix is computed.
+            self.calculate_distance_matrix()
+            rep = self.sample_representation
+        if rep is None:
+            raise RuntimeError(
+                f"{type(self).__name__} has no sample representation. Call prepare_anndata "
+                "(and, for supervised methods, get_sample_representations) before fitting a probe."
+            )
+        if not isinstance(rep, pd.DataFrame):
+            rep = pd.DataFrame(np.asarray(rep), index=self.samples)
+        return rep
+
     def fit_linear_probe(
         self,
         target: str,
@@ -364,8 +390,17 @@ class BaseSampleMethod:
         test_size: float = 0.2,
         random_state: int = 42,
         test_sample_labels: list | None = None,
+        store: bool = False,
     ) -> dict:
         """Fit a linear probe on top of sample embeddings.
+
+        The probe is a plain sklearn model (:class:`~sklearn.linear_model.Ridge`
+        for regression, balanced :class:`~sklearn.linear_model.LogisticRegression`
+        for classification) trained on the method's sample representation. This
+        works for any method that produces a per-sample embedding, including
+        supervised methods whose native head solves a *different* task (e.g.
+        training a regression probe on top of a classification model such as
+        :class:`~patpy.tl.MixMIL`).
 
         Parameters
         ----------
@@ -383,9 +418,18 @@ class BaseSampleMethod:
             Explicit list of sample labels (index values of
             :attr:`sample_representation`) to use as the test set.
             When provided, ``test_size`` and ``random_state`` are ignored.
-            When ``None``, a random split is performed and the chosen test
-            labels are stored in :attr:`test_sample_labels` for
-            reproducibility.
+            Pass an empty list to train the probe on *all* samples (no
+            held-out evaluation) — useful when fitting a probe that will be
+            applied to a different cohort. When ``None``, a random split is
+            performed and the chosen test labels are stored in
+            :attr:`test_sample_labels` for reproducibility.
+        store
+            When ``True`` (supervised methods only), register the fitted probe
+            so that :meth:`predict` can reuse it on the current (or a swapped-in)
+            cohort. The probe is saved in ``self._probes[target]`` and *target*
+            is added to ``self.label_keys`` / ``self.tasks`` if not already
+            present. This is how a regression head is attached to a
+            classification-only model.
 
         Returns
         -------
@@ -394,28 +438,45 @@ class BaseSampleMethod:
             ``"{target}_test"``, ``"{target}_pred"``.
 
             For classification: additionally ``"accuracy"`` and ``"f1"``.
-            For regression: additionally ``"r2"`` and ``"pearson"``.
+            For regression: additionally ``"r2"``, ``"pearson"``,
+            ``"spearman"`` and ``"mae"``.
+
+            Metrics are ``NaN`` when the test set is empty.
 
         Examples
         --------
         >>> result = model.fit_linear_probe(target="age", task="regression")
-        >>> print(f"Pearson r = {result['pearson']:.3f}")
+        >>> print(f"Pearson r = {result['pearson']:.3f}")  # doctest: +SKIP
+
+        Attach a regression head to a classification model and predict:
+
+        >>> model.fit_linear_probe("age", task="regression", store=True)  # doctest: +SKIP
+        >>> ages = model.predict("age")  # doctest: +SKIP
         """
+        # Note: we intentionally do not call _check_fitted() here. Representation
+        # methods never flip the _fitted flag (their embedding is computed lazily),
+        # yet they have a perfectly good sample representation to probe. Supervised
+        # methods that are not trained will instead raise when their representation
+        # is requested below.
         self._check_adata_loaded()
-        self._check_fitted()
 
         if target not in self.adata.obs.columns:
             raise ValueError(f"target='{target}' not found in adata.obs.")
+        if store and not hasattr(self, "_probes"):
+            raise AttributeError(
+                "store=True is only supported for supervised methods that maintain a `_probes` registry."
+            )
 
-        rep = self.sample_representation
+        rep = self._get_sample_representation_frame()
         all_labels = rep.index
 
         # Extract target values from adata.obs (works for all sample methods)
         target_values = self._extract_metadata(columns=[target])
 
         if test_sample_labels is not None:
-            test_idx = list(test_sample_labels)
-            train_idx = [lbl for lbl in all_labels if lbl not in set(test_idx)]
+            test_set = set(test_sample_labels)
+            test_idx = [lbl for lbl in all_labels if lbl in test_set]
+            train_idx = [lbl for lbl in all_labels if lbl not in test_set]
         else:
             from sklearn.model_selection import train_test_split
 
@@ -432,39 +493,49 @@ class BaseSampleMethod:
         X_test = rep.loc[test_idx].values
         y_train = target_values.loc[train_idx, target].values
         y_test = target_values.loc[test_idx, target].values
+        has_test = len(test_idx) > 0
 
         if task == "classification":
             from sklearn.linear_model import LogisticRegression
             from sklearn.metrics import accuracy_score, f1_score
 
-            clf = LogisticRegression(max_iter=1000, random_state=random_state, class_weight="balanced")
-            clf.fit(X_train, y_train)
-            y_pred = clf.predict(X_test)
-            return {
-                "model": clf,
+            model = LogisticRegression(max_iter=1000, random_state=random_state, class_weight="balanced")
+            model.fit(X_train, y_train)
+            y_pred = model.predict(X_test) if has_test else np.array([])
+            result = {
+                "model": model,
                 "test_sample_labels": test_idx,
                 f"{target}_test": y_test,
                 f"{target}_pred": y_pred,
-                "accuracy": accuracy_score(y_test, y_pred),
-                "f1": f1_score(y_test, y_pred, average="weighted", zero_division=0),
+                "accuracy": accuracy_score(y_test, y_pred) if has_test else np.nan,
+                "f1": f1_score(y_test, y_pred, average="weighted", zero_division=0) if has_test else np.nan,
             }
-
         elif task == "regression":
-            from scipy.stats import pearsonr
             from sklearn.linear_model import Ridge
-            from sklearn.metrics import r2_score
 
-            reg = Ridge(alpha=0.1)
-            reg.fit(X_train, y_train)
-            y_pred = reg.predict(X_test)
-            pearson_r, _ = pearsonr(y_test, y_pred)
-            return {
-                "model": reg,
+            from patpy.tl.evaluation import evaluate_regression
+
+            model = Ridge(alpha=0.1)
+            model.fit(X_train, y_train)
+            y_pred = model.predict(X_test) if has_test else np.array([])
+            metrics = evaluate_regression(y_test, y_pred) if has_test else {}
+            result = {
+                "model": model,
                 "test_sample_labels": test_idx,
                 f"{target}_test": y_test,
                 f"{target}_pred": y_pred,
-                "r2": r2_score(y_test, y_pred),
-                "pearson": pearson_r,
+                "r2": metrics.get("r2", np.nan),
+                "pearson": metrics.get("pearson", np.nan),
+                "spearman": metrics.get("spearman", np.nan),
+                "mae": metrics.get("mae", np.nan),
             }
+        else:
+            raise ValueError(f"task must be 'classification' or 'regression', got '{task}'.")
 
-        raise ValueError(f"task must be 'classification' or 'regression', got '{task}'.")
+        if store:
+            self._probes[target] = result["model"]
+            if hasattr(self, "label_keys") and target not in self.label_keys:
+                self.label_keys.append(target)
+                self.tasks.append(task)
+
+        return result

--- a/src/patpy/tl/_base_sample_method.py
+++ b/src/patpy/tl/_base_sample_method.py
@@ -365,10 +365,10 @@ class BaseSampleMethod:
         """Return the sample representation as a DataFrame indexed by sample.
 
         Works for every method flavour: representation methods set
-        :attr:`sample_representation` directly (sometimes as a plain ndarray),
-        while supervised methods may only expose it lazily through
-        :meth:`get_sample_representations`. An ndarray is wrapped using
-        :attr:`samples` as the index.
+        ``sample_representation`` directly (sometimes as a plain ndarray), while
+        supervised methods may only expose it lazily through
+        ``get_sample_representations``. An ndarray is wrapped using ``samples``
+        as the index.
         """
         if hasattr(self, "get_sample_representations"):
             # Supervised methods recompute the embedding from the current adata;
@@ -402,13 +402,12 @@ class BaseSampleMethod:
     ) -> dict:
         """Fit a linear probe on top of sample embeddings.
 
-        The probe is a plain sklearn model (:class:`~sklearn.linear_model.Ridge`
-        for regression, balanced :class:`~sklearn.linear_model.LogisticRegression`
-        for classification) trained on the method's sample representation. This
-        works for any method that produces a per-sample embedding, including
-        supervised methods whose native head solves a *different* task (e.g.
-        training a regression probe on top of a classification model such as
-        :class:`~patpy.tl.MixMIL`).
+        The probe is a plain sklearn model (``Ridge`` for regression, balanced
+        ``LogisticRegression`` for classification) trained on the method's sample
+        representation. This works for any method that produces a per-sample
+        embedding, including supervised methods whose native head solves a
+        *different* task (e.g. training a regression probe on top of a
+        classification model such as ``MixMIL``).
 
         Parameters
         ----------
@@ -424,17 +423,17 @@ class BaseSampleMethod:
             ``test_sample_labels`` is not provided).
         test_sample_labels
             Explicit list of sample labels (index values of
-            :attr:`sample_representation`) to use as the test set.
+            ``sample_representation``) to use as the test set.
             When provided, ``test_size`` and ``random_state`` are ignored.
             Pass an empty list to train the probe on *all* samples — useful
             when fitting a probe that will be applied to a different cohort; the
             returned metrics are then computed on the train set (see
             ``evaluated_on`` below). When ``None``, a random split is performed
-            and the chosen test labels are stored in :attr:`test_sample_labels`
+            and the chosen test labels are stored in ``test_sample_labels``
             for reproducibility.
         store
             When ``True`` (supervised methods only), register the fitted probe
-            so that :meth:`predict` can reuse it on the current (or a swapped-in)
+            so that ``predict`` can reuse it on the current (or a swapped-in)
             cohort. The probe is saved in ``self._probes[target]`` and *target*
             is added to ``self.label_keys`` / ``self.tasks`` if not already
             present. This is how a regression head is attached to a

--- a/src/patpy/tl/_base_sample_method.py
+++ b/src/patpy/tl/_base_sample_method.py
@@ -114,7 +114,9 @@ class BaseSampleMethod:
         filtered_layers = {
             key: np.copy(layer)
             for key, layer in self.adata.layers.items()
-            if key is not None and key != self.layer and layer.shape == self.adata.layers.get(self.layer, np.empty(0)).shape
+            if key is not None
+            and key != self.layer
+            and layer.shape == self.adata.layers.get(self.layer, np.empty(0)).shape
         }
         # Copy everything except from .var* to new adata, with correct layer in X
         new_adata = sc.AnnData(

--- a/src/patpy/tl/_base_sample_method.py
+++ b/src/patpy/tl/_base_sample_method.py
@@ -357,7 +357,7 @@ class BaseSampleMethod:
 
         return axes
 
-    def _get_sample_representation_frame(self) -> "pd.DataFrame":
+    def _get_sample_representation_frame(self) -> pd.DataFrame:
         """Return the sample representation as a DataFrame indexed by sample.
 
         Works for every method flavour: representation methods set

--- a/src/patpy/tl/_base_sample_method.py
+++ b/src/patpy/tl/_base_sample_method.py
@@ -109,7 +109,7 @@ class BaseSampleMethod:
             return self.adata
 
         # getting only those layers with the same shape of the new X matrix from adata.layers[self.layer] to be copied in the new anndata below.
-        # Newer anndata exposes ``X`` as ``layers[None]``; skip that key so we don't
+        # anndata >= 0.13 exposes ``X`` as ``layers[None]``; skip that key so we don't
         # re-inject it as a layer and clash with the explicit ``X`` passed below.
         filtered_layers = {
             key: np.copy(layer)

--- a/src/patpy/tl/_base_sample_method.py
+++ b/src/patpy/tl/_base_sample_method.py
@@ -108,11 +108,13 @@ class BaseSampleMethod:
             # The data is already in correct slot
             return self.adata
 
-        # getting only those layers with the same shape of the new X matrix from adata.layers[self.layer] to be copied in the new anndata below
+        # getting only those layers with the same shape of the new X matrix from adata.layers[self.layer] to be copied in the new anndata below.
+        # Newer anndata exposes ``X`` as ``layers[None]``; skip that key so we don't
+        # re-inject it as a layer and clash with the explicit ``X`` passed below.
         filtered_layers = {
             key: np.copy(layer)
             for key, layer in self.adata.layers.items()
-            if key != self.layer and layer.shape == self.adata.layers.get(self.layer, np.empty(0)).shape
+            if key is not None and key != self.layer and layer.shape == self.adata.layers.get(self.layer, np.empty(0)).shape
         }
         # Copy everything except from .var* to new adata, with correct layer in X
         new_adata = sc.AnnData(
@@ -366,14 +368,18 @@ class BaseSampleMethod:
         :meth:`get_sample_representations`. An ndarray is wrapped using
         :attr:`samples` as the index.
         """
-        rep = self.sample_representation
-        if rep is None and hasattr(self, "get_sample_representations"):
+        if hasattr(self, "get_sample_representations"):
+            # Supervised methods recompute the embedding from the current adata;
+            # always call it fresh so a cached representation from a previously
+            # loaded cohort is never reused (it would mis-align with the labels).
             rep = self.get_sample_representations()
-        if rep is None and hasattr(self, "calculate_distance_matrix"):
-            # Representation methods (e.g. Pseudobulk) populate sample_representation
-            # lazily when the distance matrix is computed.
-            self.calculate_distance_matrix()
+        else:
             rep = self.sample_representation
+            if rep is None and hasattr(self, "calculate_distance_matrix"):
+                # Representation methods (e.g. Pseudobulk) populate
+                # sample_representation lazily when the distance matrix is computed.
+                self.calculate_distance_matrix()
+                rep = self.sample_representation
         if rep is None:
             raise RuntimeError(
                 f"{type(self).__name__} has no sample representation. Call prepare_anndata "

--- a/src/patpy/tl/_base_sample_method.py
+++ b/src/patpy/tl/_base_sample_method.py
@@ -418,11 +418,12 @@ class BaseSampleMethod:
             Explicit list of sample labels (index values of
             :attr:`sample_representation`) to use as the test set.
             When provided, ``test_size`` and ``random_state`` are ignored.
-            Pass an empty list to train the probe on *all* samples (no
-            held-out evaluation) — useful when fitting a probe that will be
-            applied to a different cohort. When ``None``, a random split is
-            performed and the chosen test labels are stored in
-            :attr:`test_sample_labels` for reproducibility.
+            Pass an empty list to train the probe on *all* samples — useful
+            when fitting a probe that will be applied to a different cohort; the
+            returned metrics are then computed on the train set (see
+            ``evaluated_on`` below). When ``None``, a random split is performed
+            and the chosen test labels are stored in :attr:`test_sample_labels`
+            for reproducibility.
         store
             When ``True`` (supervised methods only), register the fitted probe
             so that :meth:`predict` can reuse it on the current (or a swapped-in)
@@ -434,14 +435,17 @@ class BaseSampleMethod:
         Returns
         -------
         dict
-            Keys: ``"model"``, ``"test_sample_labels"``,
+            Keys: ``"model"``, ``"test_sample_labels"``, ``"evaluated_on"``,
             ``"{target}_test"``, ``"{target}_pred"``.
 
             For classification: additionally ``"accuracy"`` and ``"f1"``.
             For regression: additionally ``"r2"``, ``"pearson"``,
             ``"spearman"`` and ``"mae"``.
 
-            Metrics are ``NaN`` when the test set is empty.
+            ``evaluated_on`` is ``"test"`` when a non-empty test set is used and
+            ``"train"`` when the probe was trained on all samples; in the latter
+            case the metrics and ``"{target}_test"``/``"{target}_pred"`` describe
+            the train set.
 
         Examples
         --------
@@ -490,10 +494,19 @@ class BaseSampleMethod:
 
         self.test_sample_labels = test_idx
         X_train = rep.loc[train_idx].values
-        X_test = rep.loc[test_idx].values
         y_train = target_values.loc[train_idx, target].values
-        y_test = target_values.loc[test_idx, target].values
-        has_test = len(test_idx) > 0
+
+        # Evaluate on the held-out test set when one is given; otherwise fall back to
+        # the train set so the returned metrics describe the fitted probe instead of
+        # being empty. ``evaluated_on`` records which set the metrics refer to.
+        if len(test_idx) > 0:
+            eval_X = rep.loc[test_idx].values
+            eval_y = target_values.loc[test_idx, target].values
+            evaluated_on = "test"
+        else:
+            eval_X = X_train
+            eval_y = y_train
+            evaluated_on = "train"
 
         if task == "classification":
             from sklearn.linear_model import LogisticRegression
@@ -501,14 +514,15 @@ class BaseSampleMethod:
 
             model = LogisticRegression(max_iter=1000, random_state=random_state, class_weight="balanced")
             model.fit(X_train, y_train)
-            y_pred = model.predict(X_test) if has_test else np.array([])
+            y_pred = model.predict(eval_X)
             result = {
                 "model": model,
                 "test_sample_labels": test_idx,
-                f"{target}_test": y_test,
+                "evaluated_on": evaluated_on,
+                f"{target}_test": eval_y,
                 f"{target}_pred": y_pred,
-                "accuracy": accuracy_score(y_test, y_pred) if has_test else np.nan,
-                "f1": f1_score(y_test, y_pred, average="weighted", zero_division=0) if has_test else np.nan,
+                "accuracy": accuracy_score(eval_y, y_pred),
+                "f1": f1_score(eval_y, y_pred, average="weighted", zero_division=0),
             }
         elif task == "regression":
             from sklearn.linear_model import Ridge
@@ -517,17 +531,18 @@ class BaseSampleMethod:
 
             model = Ridge(alpha=0.1)
             model.fit(X_train, y_train)
-            y_pred = model.predict(X_test) if has_test else np.array([])
-            metrics = evaluate_regression(y_test, y_pred) if has_test else {}
+            y_pred = model.predict(eval_X)
+            metrics = evaluate_regression(eval_y, y_pred)
             result = {
                 "model": model,
                 "test_sample_labels": test_idx,
-                f"{target}_test": y_test,
+                "evaluated_on": evaluated_on,
+                f"{target}_test": eval_y,
                 f"{target}_pred": y_pred,
-                "r2": metrics.get("r2", np.nan),
-                "pearson": metrics.get("pearson", np.nan),
-                "spearman": metrics.get("spearman", np.nan),
-                "mae": metrics.get("mae", np.nan),
+                "r2": metrics["r2"],
+                "pearson": metrics["pearson"],
+                "spearman": metrics["spearman"],
+                "mae": metrics["mae"],
             }
         else:
             raise ValueError(f"task must be 'classification' or 'regression', got '{task}'.")

--- a/src/patpy/tl/evaluation.py
+++ b/src/patpy/tl/evaluation.py
@@ -366,36 +366,30 @@ def evaluate_prediction(y_true, y_pred, task, **parameters):
 
 
 def evaluate_regression(y_true, y_pred):
-    """Compute standard regression metrics between true and predicted values.
+    """Compute standard regression metrics between true and predicted values
 
     A general-purpose helper (not tied to any particular target) that returns
     the metrics most commonly reported for continuous predictions. Pairs in
-    which either ``y_true`` or ``y_pred`` is non-finite (NaN/inf) are dropped
-    before scoring. When fewer than three valid pairs remain the metrics are
-    not well defined and are returned as ``NaN``.
+    which either `y_true` or `y_pred` is non-finite (NaN/inf) are dropped before
+    scoring. When fewer than three valid pairs remain the metrics are not well
+    defined and are returned as NaN.
 
     Parameters
     ----------
     y_true : array-like
-        Ground-truth continuous values.
+        Ground-truth continuous values
     y_pred : array-like
-        Predicted continuous values, aligned with ``y_true``.
+        Predicted continuous values, aligned with `y_true`
 
     Returns
     -------
     result : dict
-        Dictionary with the following keys:
-
-        - ``r2``: coefficient of determination (:func:`sklearn.metrics.r2_score`)
-        - ``spearman``: Spearman rank correlation
-        - ``pearson``: Pearson correlation
-        - ``mae``: mean absolute error
-        - ``n``: number of valid (finite) pairs used for scoring
-
-    Examples
-    --------
-    >>> evaluate_regression([1, 2, 3, 4], [1.1, 1.9, 3.2, 3.8])["mae"]  # doctest: +SKIP
-    0.15
+        Result of evaluation with the following keys:
+        - r2: coefficient of determination (`sklearn.metrics.r2_score`)
+        - spearman: Spearman rank correlation
+        - pearson: Pearson correlation
+        - mae: mean absolute error
+        - n: number of valid (finite) pairs used for scoring
     """
     from scipy.stats import pearsonr, spearmanr
     from sklearn.metrics import mean_absolute_error, r2_score

--- a/src/patpy/tl/evaluation.py
+++ b/src/patpy/tl/evaluation.py
@@ -365,6 +365,71 @@ def evaluate_prediction(y_true, y_pred, task, **parameters):
     return {"score": score, "metric": metric}
 
 
+def evaluate_regression(y_true, y_pred):
+    """Compute standard regression metrics between true and predicted values.
+
+    A general-purpose helper (not tied to any particular target) that returns
+    the metrics most commonly reported for continuous predictions. Pairs in
+    which either ``y_true`` or ``y_pred`` is non-finite (NaN/inf) are dropped
+    before scoring. When fewer than three valid pairs remain the metrics are
+    not well defined and are returned as ``NaN``.
+
+    Parameters
+    ----------
+    y_true : array-like
+        Ground-truth continuous values.
+    y_pred : array-like
+        Predicted continuous values, aligned with ``y_true``.
+
+    Returns
+    -------
+    result : dict
+        Dictionary with the following keys:
+
+        - ``r2``: coefficient of determination (:func:`sklearn.metrics.r2_score`)
+        - ``spearman``: Spearman rank correlation
+        - ``pearson``: Pearson correlation
+        - ``mae``: mean absolute error
+        - ``n``: number of valid (finite) pairs used for scoring
+
+    Examples
+    --------
+    >>> evaluate_regression([1, 2, 3, 4], [1.1, 1.9, 3.2, 3.8])["mae"]  # doctest: +SKIP
+    0.15
+    """
+    from scipy.stats import pearsonr, spearmanr
+    from sklearn.metrics import mean_absolute_error, r2_score
+
+    y_true = np.asarray(y_true, dtype=float)
+    y_pred = np.asarray(y_pred, dtype=float)
+    if y_true.shape != y_pred.shape:
+        raise ValueError(f"y_true and y_pred must have the same shape, got {y_true.shape} and {y_pred.shape}.")
+
+    valid = np.isfinite(y_true) & np.isfinite(y_pred)
+    n_valid = int(valid.sum())
+    nan_result = {"r2": np.nan, "spearman": np.nan, "pearson": np.nan, "mae": np.nan, "n": n_valid}
+    if n_valid < 3:
+        return nan_result
+
+    y_true, y_pred = y_true[valid], y_pred[valid]
+
+    # Correlations are undefined when either input is constant; guard against it.
+    if np.std(y_true) < 1e-12 or np.std(y_pred) < 1e-12:
+        spearman = np.nan
+        pearson = np.nan
+    else:
+        spearman = float(spearmanr(y_true, y_pred).statistic)
+        pearson = float(pearsonr(y_true, y_pred)[0])
+
+    return {
+        "r2": float(r2_score(y_true, y_pred)),
+        "spearman": spearman,
+        "pearson": pearson,
+        "mae": float(mean_absolute_error(y_true, y_pred)),
+        "n": n_valid,
+    }
+
+
 def test_proportions(target, groups):
     """Run statistical test to check if distribution of `target` differs between `groups`
 

--- a/src/patpy/tl/supervised.py
+++ b/src/patpy/tl/supervised.py
@@ -1553,6 +1553,7 @@ class PaSCient(SupervisedSampleMethod):
         emb_dim = self.patient_emb_dim  # 512
 
         if task == "regression":
+
             class _RegressionLoss(nn.Module):
                 """MSE between predicted scalar and target, averaged over the (single) view."""
 
@@ -1685,7 +1686,10 @@ class PaSCient(SupervisedSampleMethod):
 
         if self._pascient_model is None:
             self._pascient_model = self._build_model(
-                n_genes, n_classes, class_counts=class_counts, task=task,
+                n_genes,
+                n_classes,
+                class_counts=class_counts,
+                task=task,
             )
 
         # -- Dataset that produces SampleBatch per donor ----------------

--- a/src/patpy/tl/supervised.py
+++ b/src/patpy/tl/supervised.py
@@ -140,11 +140,11 @@ class SupervisedSampleMethod(BaseSampleMethod):
     def _predict_with_probe(self, label: str) -> pd.Series | pd.DataFrame:
         """Predict `label` with the fitted sklearn probe in ``self._probes``.
 
-        Shared by the default :meth:`predict` and by subclasses with a native
-        head (e.g. MixMIL) that nonetheless carry a probe for a task their
-        native likelihood cannot solve. The probe runs on the *current*
-        :meth:`get_sample_representations`, so swapping ``self.adata`` to a new
-        cohort and calling :meth:`predict` yields cross-cohort predictions.
+        Shared by the default ``predict`` and by subclasses with a native head
+        (e.g. MixMIL) that nonetheless carry a probe for a task their native
+        likelihood cannot solve. The probe runs on the *current*
+        ``get_sample_representations``, so swapping ``self.adata`` to a new cohort
+        and calling ``predict`` yields cross-cohort predictions.
         """
         task = self.tasks[self.label_keys.index(label)]
         rep = self.get_sample_representations()

--- a/src/patpy/tl/supervised.py
+++ b/src/patpy/tl/supervised.py
@@ -135,6 +135,17 @@ class SupervisedSampleMethod(BaseSampleMethod):
         if label not in self._probes:
             raise RuntimeError(f"No probe fitted for label '{label}'. Call fine_tune() first.")
 
+        return self._predict_with_probe(label)
+
+    def _predict_with_probe(self, label: str) -> pd.Series | pd.DataFrame:
+        """Predict `label` with the fitted sklearn probe in ``self._probes``.
+
+        Shared by the default :meth:`predict` and by subclasses with a native
+        head (e.g. MixMIL) that nonetheless carry a probe for a task their
+        native likelihood cannot solve. The probe runs on the *current*
+        :meth:`get_sample_representations`, so swapping ``self.adata`` to a new
+        cohort and calling :meth:`predict` yields cross-cohort predictions.
+        """
         task = self.tasks[self.label_keys.index(label)]
         rep = self.get_sample_representations()
         X = rep.values
@@ -630,6 +641,12 @@ class MixMIL(SupervisedSampleMethod):
         self._check_fitted()
         if label not in self.label_keys:
             raise ValueError(f"`label='{label}'` is not found in model label keys.")
+
+        # A linear probe attached via fit_linear_probe(..., store=True) takes
+        # precedence: it lets MixMIL serve tasks (e.g. continuous regression)
+        # that its binomial/categorical native head cannot.
+        if label in self._probes:
+            return self._predict_with_probe(label)
 
         task = self.tasks[self.label_keys.index(label)]
 
@@ -1483,7 +1500,13 @@ class PaSCient(SupervisedSampleMethod):
         self._extract_embeddings(adata)
         self._fitted = True
 
-    def _build_model(self, n_genes: int, n_classes: int, class_counts: list[int] | None = None):
+    def _build_model(
+        self,
+        n_genes: int,
+        n_classes: int,
+        class_counts: list[int] | None = None,
+        task: str = "classification",
+    ):
         """Build a fresh PaSCient model from pascient component classes.
 
         Parameters
@@ -1491,17 +1514,21 @@ class PaSCient(SupervisedSampleMethod):
         n_genes
             Number of input genes.
         n_classes
-            Number of prediction outputs.
+            Number of prediction outputs (set to ``1`` for regression).
         class_counts
-            Per-class sample counts for loss weighting.  When provided,
-            ``CrossEntropyLossViews`` uses inverse counts so that
+            Per-class sample counts for loss weighting (classification only).
+            When provided, ``CrossEntropyLossViews`` uses inverse counts so
             under-represented classes receive higher loss.
+        task
+            ``"classification"`` (default) routes through
+            ``CrossEntropyLossViews``. ``"regression"`` swaps in a per-view
+            mean-squared error loss.
 
         Returns
         -------
         pascient.model.sample_predictor.SamplePredictor
             A ``SamplePredictor`` instance with the default PaSCient
-            architecture.
+            architecture and a task-appropriate prediction loss.
         """
         from functools import partial
         from types import SimpleNamespace
@@ -1525,16 +1552,36 @@ class PaSCient(SupervisedSampleMethod):
         latent_dim = self.latent_dim  # 1024
         emb_dim = self.patient_emb_dim  # 512
 
-        from pascient.components.losses import CrossEntropyLossViews
+        if task == "regression":
+            class _RegressionLoss(nn.Module):
+                """MSE between predicted scalar and target, averaged over the (single) view."""
 
-        # Minimal losses config expected by SamplePredictor.init_losses()
-        # CrossEntropyLossViews internally inverts the weights (1/w),
-        # so passing class counts upweights rare classes.
-        loss_kwargs = {"weight": class_counts} if class_counts is not None else {}
+                def __init__(self):
+                    super().__init__()
+                    self.mse = nn.MSELoss()
+
+                def forward(self, logits, target):
+                    # logits: (B, V, 1) where V = #views. target: (B,) or (B, 1).
+                    if logits.ndim == 3 and logits.shape[-1] == 1:
+                        logits = logits.squeeze(-1)
+                    if logits.ndim == 2 and logits.shape[1] == 1:
+                        logits = logits.squeeze(1)
+                    target = target.to(logits.dtype).view(logits.shape)
+                    return self.mse(logits, target)
+
+            loss_factory = _RegressionLoss
+        else:
+            from pascient.components.losses import CrossEntropyLossViews
+
+            # CrossEntropyLossViews internally inverts the weights (1/w),
+            # so passing class counts upweights rare classes.
+            loss_kwargs = {"weight": class_counts} if class_counts is not None else {}
+            loss_factory = partial(CrossEntropyLossViews, **loss_kwargs)
+
         losses = SimpleNamespace(
             sample_prediction_loss=SimpleNamespace(
                 weight=1.0,
-                loss_fn=partial(CrossEntropyLossViews, **loss_kwargs),
+                loss_fn=loss_factory,
                 labels=self.label_keys[:1],
             ),
         )
@@ -1618,15 +1665,28 @@ class PaSCient(SupervisedSampleMethod):
             # receive higher loss via CrossEntropyLossViews's 1/w scheme).
             class_counts = [int((label_vals == c).sum()) for c in classes]
         else:
+            # Regression: z-score the target so MSE is on a unit scale.
+            # Without this, raw targets like ages (40-89) make the initial
+            # loss ~thousands and gradients explode into NaN within a few
+            # steps. We store the mean/std so ``_predict_native`` can
+            # de-normalise back to the original scale.
             n_classes = 1
-            y_map = {d: float(v) for d, v in zip(self.labels.index, label_vals, strict=True)}
+            float_vals = np.asarray(label_vals, dtype=np.float64)
+            self._regression_mean = float(np.nanmean(float_vals))
+            self._regression_std = float(np.nanstd(float_vals)) or 1.0
+            y_map = {
+                d: float((v - self._regression_mean) / self._regression_std)
+                for d, v in zip(self.labels.index, label_vals, strict=True)
+            }
             self._class_names = None
             class_counts = None
 
         self._trained_label = label_key
 
         if self._pascient_model is None:
-            self._pascient_model = self._build_model(n_genes, n_classes, class_counts=class_counts)
+            self._pascient_model = self._build_model(
+                n_genes, n_classes, class_counts=class_counts, task=task,
+            )
 
         # -- Dataset that produces SampleBatch per donor ----------------
 
@@ -1687,6 +1747,8 @@ class PaSCient(SupervisedSampleMethod):
             enable_checkpointing=False,
             logger=False,
             enable_progress_bar=True,
+            gradient_clip_val=1.0,
+            gradient_clip_algorithm="norm",
         )
         self._pascient_model.train()
         trainer.fit(self._pascient_model, train_dataloaders=train_dl, val_dataloaders=val_dl)
@@ -2083,7 +2145,10 @@ class PaSCient(SupervisedSampleMethod):
             result[f"{label}_pred"] = [classes[i] for i in proba.argmax(axis=1)]
             return result
         else:
-            return pd.Series(preds_arr.ravel(), index=donor_ids, name=label)
+            # De-normalise the z-scored target back to the original scale.
+            mean = getattr(self, "_regression_mean", 0.0)
+            std = getattr(self, "_regression_std", 1.0)
+            return pd.Series(preds_arr.ravel() * std + mean, index=donor_ids, name=label)
 
     def get_sample_importance(self, force: bool = False) -> pd.DataFrame:
         """Per-donor importance derived from the L2 norm of patient embeddings.

--- a/src/patpy/tl/supervised.py
+++ b/src/patpy/tl/supervised.py
@@ -832,7 +832,12 @@ class MixMIL(SupervisedSampleMethod):
         self._check_adata_loaded()
         import torch
 
-        Xs, _, _ = self._build_bags()
+        # `_build_bags` returns donors in pd.Categorical (alphabetical) order; the
+        # embeddings below follow that same order, so we index by `categories` (and
+        # align `self.samples` to it) rather than the possibly-differently-ordered
+        # `self.samples`. This keeps donor labels matched to their embeddings even
+        # when the model is re-pointed at a new cohort.
+        Xs, categories, _ = self._build_bags()
 
         with torch.no_grad():
             w, _ = self._model.get_weights(Xs)
@@ -846,7 +851,8 @@ class MixMIL(SupervisedSampleMethod):
 
         embeddings_arr = np.stack(embeddings)
         cols = [f"dim_{i}" for i in range(embeddings_arr.shape[1])]
-        self.sample_representation = pd.DataFrame(embeddings_arr, index=self.samples, columns=cols)
+        self.samples = categories
+        self.sample_representation = pd.DataFrame(embeddings_arr, index=categories, columns=cols)
 
         return self.sample_representation
 

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -10,6 +10,7 @@ from patpy.tl.evaluation import (
     _permanova_ss_w,
     _select_random_subset,
     evaluate_prediction,
+    evaluate_regression,
     evaluate_representation,
     knn_prediction_score,
     permanova_pseudo_f_statistic,
@@ -338,3 +339,58 @@ def test_replicate_robustness_intermediate():
     # Half the samples have replicate at rank 0; the other half at rank n-2.
     # Mean rank = (n-2)/2; normalised score = 1 - 0.5 = 0.5.
     assert score == pytest.approx(0.5)
+
+
+# A perfect prediction should score r2/pearson == 1 and mae == 0.
+def test_evaluate_regression_perfect_fit():
+    y_true = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+    result = evaluate_regression(y_true, y_true.copy())
+
+    assert result["n"] == 5
+    assert result["r2"] == pytest.approx(1.0)
+    assert result["pearson"] == pytest.approx(1.0)
+    assert result["spearman"] == pytest.approx(1.0)
+    assert result["mae"] == pytest.approx(0.0)
+
+
+# Non-finite pairs are dropped before scoring; only the finite ones count.
+def test_evaluate_regression_drops_non_finite():
+    y_true = np.array([1.0, 2.0, 3.0, 4.0, np.nan])
+    y_pred = np.array([1.0, 2.0, 3.0, np.inf, 5.0])
+
+    result = evaluate_regression(y_true, y_pred)
+
+    # The last two pairs contain nan/inf and are dropped, leaving 3 valid pairs.
+    assert result["n"] == 3
+    assert result["mae"] == pytest.approx(0.0)
+
+
+# Fewer than three valid pairs leaves the metrics undefined (NaN).
+def test_evaluate_regression_too_few_points():
+    result = evaluate_regression([1.0, 2.0], [1.0, 2.0])
+
+    assert result["n"] == 2
+    assert np.isnan(result["r2"])
+    assert np.isnan(result["spearman"])
+    assert np.isnan(result["pearson"])
+    assert np.isnan(result["mae"])
+
+
+# A constant prediction makes the correlations undefined but keeps r2/mae finite.
+def test_evaluate_regression_constant_prediction():
+    y_true = np.array([1.0, 2.0, 3.0, 4.0])
+    y_pred = np.array([2.5, 2.5, 2.5, 2.5])
+
+    result = evaluate_regression(y_true, y_pred)
+
+    assert np.isnan(result["spearman"])
+    assert np.isnan(result["pearson"])
+    assert np.isfinite(result["r2"])
+    assert result["mae"] == pytest.approx(1.0)
+
+
+# Mismatched shapes are a programming error and should raise.
+def test_evaluate_regression_shape_mismatch():
+    with pytest.raises(ValueError):
+        evaluate_regression([1.0, 2.0, 3.0], [1.0, 2.0])

--- a/tests/test_sample_representation_methods.py
+++ b/tests/test_sample_representation_methods.py
@@ -1144,7 +1144,27 @@ def test_fit_linear_probe_regression_on_ndarray_representation(synthetic_adata):
     assert isinstance(result["model"], Ridge)
     assert set(result["test_sample_labels"]) == set(test_samples)
     assert {"r2", "pearson", "spearman", "mae"} <= result.keys()
+    assert result["evaluated_on"] == "test"
     assert len(result["age_pred"]) == len(test_samples)
+
+
+# An empty test set trains on all samples and reports metrics on the train set
+# (not NaN), flagging evaluated_on="train".
+def test_fit_linear_probe_empty_test_evaluates_on_train(synthetic_adata):
+    adata = synthetic_adata.copy()
+    samples = adata.obs[SAMPLE_KEY].unique().tolist()
+    adata.obs["age"] = adata.obs[SAMPLE_KEY].map({s: float(20 + 5 * i) for i, s in enumerate(samples)}).astype(float)
+
+    method = Pseudobulk(sample_key=SAMPLE_KEY, cell_group_key=CELL_KEY, layer="X")
+    method.prepare_anndata(adata)
+    result = method.fit_linear_probe("age", task="regression", test_sample_labels=[])
+
+    assert result["evaluated_on"] == "train"
+    assert result["test_sample_labels"] == []
+    assert np.isfinite(result["r2"])
+    assert np.isfinite(result["mae"])
+    # all samples were used for training, and the metrics are reported on them
+    assert len(result["age_pred"]) == len(samples)
 
 
 # store=True only makes sense for supervised methods (which keep a _probes registry).

--- a/tests/test_sample_representation_methods.py
+++ b/tests/test_sample_representation_methods.py
@@ -1119,3 +1119,41 @@ class TestSampleOrderingConsistency:
                 method._distances,
                 err_msg=f"{cls.__name__}: cached distance matrix doesn't match returned value",
             )
+
+
+# Pseudobulk stores its sample representation as a plain ndarray (not a DataFrame);
+# fit_linear_probe must still work by wrapping it with the sample index.
+def test_fit_linear_probe_regression_on_ndarray_representation(synthetic_adata):
+    adata = synthetic_adata.copy()
+    samples = adata.obs[SAMPLE_KEY].unique().tolist()
+    # Attach a continuous per-sample target.
+    sample_age = {sample: float(20 + 5 * i) for i, sample in enumerate(samples)}
+    adata.obs["age"] = adata.obs[SAMPLE_KEY].map(sample_age).astype(float)
+
+    method = Pseudobulk(sample_key=SAMPLE_KEY, cell_group_key=CELL_KEY, layer="X")
+    method.prepare_anndata(adata)
+
+    # Pseudobulk's representation is a bare ndarray — the probe must not choke on it.
+    assert not isinstance(method.sample_representation, pd.DataFrame)
+
+    test_samples = samples[:3]
+    result = method.fit_linear_probe("age", task="regression", test_sample_labels=test_samples)
+
+    from sklearn.linear_model import Ridge
+
+    assert isinstance(result["model"], Ridge)
+    assert set(result["test_sample_labels"]) == set(test_samples)
+    assert {"r2", "pearson", "spearman", "mae"} <= result.keys()
+    assert len(result["age_pred"]) == len(test_samples)
+
+
+# store=True only makes sense for supervised methods (which keep a _probes registry).
+def test_fit_linear_probe_store_unsupported_on_representation_method(synthetic_adata):
+    adata = synthetic_adata.copy()
+    adata.obs["age"] = adata.obs[SAMPLE_KEY].astype("category").cat.codes.astype(float)
+
+    method = Pseudobulk(sample_key=SAMPLE_KEY, cell_group_key=CELL_KEY, layer="X")
+    method.prepare_anndata(adata)
+
+    with pytest.raises(AttributeError, match="_probes"):
+        method.fit_linear_probe("age", task="regression", store=True)

--- a/tests/test_supervised_methods.py
+++ b/tests/test_supervised_methods.py
@@ -1481,3 +1481,49 @@ class TestEdgeCases:
         """fit_linear_probe should raise ValueError if target not in adata.obs."""
         with pytest.raises(ValueError, match="not found in adata.obs"):
             pulsar_model.fit_linear_probe(target="nonexistent_column", task="regression")
+
+
+# ---------------------------------------------------------------------------
+# Linear-probe regression head on a classification-only model (MixMIL)
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_mixmil
+def test_mixmil_fit_linear_probe_regression(mixmil_model):
+    """A regression probe can be fit on MixMIL's representation (native head is binomial)."""
+    from sklearn.linear_model import Ridge
+
+    test_samples = ["donor_00", "donor_01", "donor_02"]
+    result = mixmil_model.fit_linear_probe("age", task="regression", test_sample_labels=test_samples)
+
+    assert isinstance(result["model"], Ridge)
+    assert {"r2", "pearson", "spearman", "mae"} <= result.keys()
+    assert len(result["age_pred"]) == len(test_samples)
+
+
+@_skip_no_mixmil
+def test_mixmil_predict_via_stored_regression_probe(mixmil_model):
+    """store=True attaches a regression head so predict() returns continuous values."""
+    mixmil_model.fit_linear_probe("age", task="regression", test_sample_labels=[], store=True)
+
+    assert "age" in mixmil_model.label_keys
+    assert "age" in mixmil_model._probes
+    assert mixmil_model.tasks[mixmil_model.label_keys.index("age")] == "regression"
+
+    predictions = mixmil_model.predict("age")
+
+    assert isinstance(predictions, pd.Series)
+    assert len(predictions) == N_DONORS
+    assert np.issubdtype(predictions.values.dtype, np.floating)
+    assert list(predictions.index) == list(mixmil_model.samples)
+
+
+@_skip_no_mixmil
+def test_mixmil_native_classification_still_works_after_storing_probe(mixmil_model):
+    """Storing a regression probe must not break the native classification head."""
+    mixmil_model.fit_linear_probe("age", task="regression", test_sample_labels=[], store=True)
+
+    # The native binomial head still serves the originally trained label.
+    disease_pred = mixmil_model.predict("disease")
+    assert isinstance(disease_pred, pd.DataFrame)
+    assert "disease_pred" in disease_pred.columns

--- a/tests/test_supervised_methods.py
+++ b/tests/test_supervised_methods.py
@@ -1527,3 +1527,25 @@ def test_mixmil_native_classification_still_works_after_storing_probe(mixmil_mod
     disease_pred = mixmil_model.predict("disease")
     assert isinstance(disease_pred, pd.DataFrame)
     assert "disease_pred" in disease_pred.columns
+
+
+@_skip_no_mixmil
+def test_mixmil_probe_predict_survives_cohort_swap(mixmil_model, basic_adata):
+    """A model reused across cohorts must not reuse a stale representation cache.
+
+    Regression test: fit a probe on cohort A, then re-point the model at cohort B
+    (different donor IDs) and predict. Previously the cached sample_representation
+    from A leaked into the probe lookup and raised a KeyError; the prediction must
+    now be indexed by cohort B's donors.
+    """
+    mixmil_model.fit_linear_probe("age", task="regression", test_sample_labels=[], store=True)
+
+    cohort_b = basic_adata.copy()
+    cohort_b.obs["donor_id"] = "B_" + cohort_b.obs["donor_id"].astype(str)
+    mixmil_model.adata = cohort_b
+    mixmil_model.samples = pd.unique(cohort_b.obs["donor_id"]).tolist()
+
+    predictions = mixmil_model.predict("age")
+
+    assert set(predictions.index) == set(cohort_b.obs["donor_id"].unique())
+    assert np.issubdtype(predictions.values.dtype, np.floating)


### PR DESCRIPTION

- `patpy.tl.evaluate_regression(y_true, y_pred)`: general-purpose regression metrics (`r2`, `spearman`, `pearson`, `mae`, `n`) for any predicted/true vectors, with non-finite masking and `NaN` when fewer than three valid pairs remain.
- `PaSCient` regression support: `tasks=["regression"]` trains a per-view MSE head with automatic target standardisation, enabling continuous donor-level targets (e.g. age) instead of only classification.
- `BaseSampleMethod.fit_linear_probe(..., store=True)` registers the fitted probe in `self._probes` so `predict()` can serve it afterwards — e.g. attaching a continuous-regression head on top of a classification-only model such as `MixMIL`.

### Changed

- `fit_linear_probe` now also works for sample-representation methods whose embedding is a plain ndarray or is computed lazily (via `calculate_distance_matrix`), tolerates an empty test set (train on all samples, for a transferable probe), and returns `spearman` and `mae` alongside `r2`/`pearson` for regression.
- Supervised `predict()` resolves probe-backed labels through a shared `_predict_with_probe`; `MixMIL.predict` uses a stored regression probe when one is present, so a continuous target can ride on top of its binomial head.